### PR TITLE
Leaderboards functions

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -5,3 +5,4 @@ IndentPPDirectives: AfterHash
 ColumnLimit: 1000000
 FixNamespaceComments: true
 SpacesBeforeTrailingComments: 1
+AllowShortIfStatementsOnASingleLine: true

--- a/.clang-format
+++ b/.clang-format
@@ -5,4 +5,4 @@ IndentPPDirectives: AfterHash
 ColumnLimit: 1000000
 FixNamespaceComments: true
 SpacesBeforeTrailingComments: 1
-AllowShortIfStatementsOnASingleLine: true
+AllowShortIfStatementsOnASingleLine: false

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 SRC=luasteam.cxx
 STDLIB_VER=-std=c++11
 
+# -Wno-invalid-offsetof prevents STEAM_CALLBACK from giving out warnings
+CPP_FLAGS=-Wno-invalid-offsetof -Wall
+
 OSX_OUT=luasteam.so
 OSX_IPATHS=-I/usr/local/include/luajit-2.0
 OSX_FLAGS=$(OSX_IPATHS) $(STDLIB_VER) -lluajit-5.1
@@ -20,16 +23,16 @@ all:
 STEAM_LIB=sdk/redistributable_bin
 
 osx:
-	$(CXX) $(SRC) ${STEAM_LIB}/osx32/libsteam_api.dylib -o $(OSX_OUT) -shared -fPIC $(OSX_FLAGS)
+	$(CXX) $(SRC) $(CPP_FLAGS) ${STEAM_LIB}/osx32/libsteam_api.dylib -o $(OSX_OUT) -shared -fPIC $(OSX_FLAGS)
 
 linux32:
-	$(CXX) $(SRC) ${STEAM_LIB}/linux32/libsteam_api.so -m32 -o $(GNU_OUT) -shared -fPIC $(GNU_FLAGS)
+	$(CXX) $(SRC) $(CPP_FLAGS) ${STEAM_LIB}/linux32/libsteam_api.so -m32 -o $(GNU_OUT) -shared -fPIC $(GNU_FLAGS)
 
 linux64:
-	$(CXX) $(SRC) ${STEAM_LIB}/linux64/libsteam_api.so -o $(GNU_OUT) -shared -fPIC $(GNU_FLAGS)
+	$(CXX) $(SRC) $(CPP_FLAGS) ${STEAM_LIB}/linux64/libsteam_api.so -o $(GNU_OUT) -shared -fPIC $(GNU_FLAGS)
 
 windows32:
-	$(CXX) $(SRC) lua51.lib ${STEAM_LIB}/steam_api.lib $(WINDOWS_IPATHS) /LD /EHsc
+	$(CXX) $(SRC) $(CPP_FLAGS) lua51.lib ${STEAM_LIB}/steam_api.lib $(WINDOWS_IPATHS) /LD /EHsc
 
 windows64:
-	$(CXX) $(SRC) lua51.lib ${STEAM_LIB}/win64/steam_api64.lib $(WINDOWS_IPATHS) /LD /EHsc
+	$(CXX) $(SRC) $(CPP_FLAGS) lua51.lib ${STEAM_LIB}/win64/steam_api64.lib $(WINDOWS_IPATHS) /LD /EHsc

--- a/README.md
+++ b/README.md
@@ -2,37 +2,9 @@
 
 Lua bindings for SteamWorks API
 
-## Usage
+## Documentation
 
-To use luasteam in your game, you just need to place the appropriate library files together with your lua files.
-
-Download the SteamWorks SDK, then copy the following files to the same directory as your lua files. The files needed from this repository can be found in the [Releases page](https://github.com/uspgamedev/luasteam/releases).
-
-- Linux 32: `luasteam.so` from this repository and `sdk/redistributable_bin/linux32/libsteam_api.so` from the SDK.
-- Linux 64: `luasteam.so` from this repository and `sdk/redistributable_bin/linux64/libsteam_api.so` from the SDK.
-- Windows 32: `luasteam.dll` from this repository and `sdk/redistributable_bin/steam_api.dll` from the SDK.
-- Windows 64: `luasteam.dll` from this repository and `sdk/redistributable_bin/win64/steam_api64.dll` from the SDK.
-- OSX: `luasteam.so` from this repository and `sdk/redistributable_bin/osx32/libsteam_api.dylib` from the SDK.
-
-Then, you can use luasteam as an usual lua library. For example:
-
-```lua
-local luasteam = require('luasteam') -- You must do this before OpenGL is loaded!
--- ...
-luasteam.userStats.resetAllStats(true) -- resetting everything for the user
-
-function luasteam.friends.onGameOverlayActivated(active)
-    print('Overlay is active: ' .. (active and 'true' or 'false'))
-end
-
-function yourGameLoop()
-    -- You need to call this very often to make sure your callbacks work
-    Steam.runCallbacks()
-end
-
--- ...
-luasteam.shutdown() -- Don't forget to shutdown the API when your game is closed
-```
+**Coming soon**
 
 ## Building from scratch
 

--- a/luasteam.cxx
+++ b/luasteam.cxx
@@ -308,6 +308,8 @@ EXTERN int luasteam_downloadLeaderboardEntries(lua_State *L) {
 
 namespace {
 
+const char *dialog_types[] = {"friends", "community", "players", "settings", "officialgamegroup", "stats", "achievements", NULL};
+
 class SteamFriendsListener {
   private:
     STEAM_CALLBACK(SteamFriendsListener, OnGameOverlayActivated, GameOverlayActivated_t);
@@ -334,7 +336,7 @@ void SteamFriendsListener::OnGameOverlayActivated(GameOverlayActivated_t *data) 
 
 // void ActivateGameOverlay( const char *pchDialog );
 EXTERN int luasteam_activateGameOverlay(lua_State *L) {
-    const char *dialog = luaL_checkstring(L, 1);
+    const char *dialog = dialog_types[luaL_checkoption(L, 1, NULL, dialog_types)];
     SteamFriends()->ActivateGameOverlay(dialog);
     return 0;
 }

--- a/luasteam.cxx
+++ b/luasteam.cxx
@@ -84,9 +84,9 @@ void SteamUserStatsListener::OnLeaderboardFindResult(LeaderboardFindResult_t *da
     luaL_unref(L, LUA_REGISTRYINDEX, leaderboardFindResultCallback_ref);
     leaderboardFindResultCallback_ref = LUA_NOREF;
     // calling function
-    if (io_fail)
+    if (io_fail) {
         lua_pushnil(L);
-    else {
+    } else {
         lua_createtable(L, 0, 2);
         pushuint64(L, data->m_hSteamLeaderboard);
         lua_setfield(L, -2, "steamLeaderboard");
@@ -104,9 +104,9 @@ void SteamUserStatsListener::OnLeaderboardScoreUploaded(LeaderboardScoreUploaded
     luaL_unref(L, LUA_REGISTRYINDEX, leaderboardScoreUploadedCallback_ref);
     leaderboardScoreUploadedCallback_ref = LUA_NOREF;
     // calling function
-    if (io_fail)
+    if (io_fail) {
         lua_pushnil(L);
-    else {
+    } else {
         lua_createtable(L, 0, 2);
         lua_pushboolean(L, data->m_bSuccess != 0);
         lua_setfield(L, -2, "success");
@@ -132,9 +132,9 @@ void SteamUserStatsListener::OnLeaderboardScoresDownloaded(LeaderboardScoresDown
     luaL_unref(L, LUA_REGISTRYINDEX, leaderboardScoresDownloadedCallback_ref);
     leaderboardScoresDownloadedCallback_ref = LUA_NOREF;
     // calling function
-    if (io_fail)
+    if (io_fail) {
         lua_pushnil(L);
-    else {
+    } else {
         lua_createtable(L, data->m_cEntryCount, 0);
         LeaderboardEntry_t entry;
         int32 details[k_cLeaderboardDetailsMax];
@@ -170,9 +170,9 @@ void SteamUserStatsListener::OnUserStatsReceived(UserStatsReceived_t *data) {
     if (!lua_checkstack(L, 4)) return;
     lua_rawgeti(L, LUA_REGISTRYINDEX, userStats_ref);
     lua_getfield(L, -1, "onUserStatsReceived");
-    if (lua_isnil(L, -1))
+    if (lua_isnil(L, -1)) {
         lua_pop(L, 2);
-    else {
+    } else {
         lua_createtable(L, 0, 3);
         pushuint64(L, data->m_nGameID);
         lua_setfield(L, -2, "gameID");
@@ -191,9 +191,9 @@ void SteamUserStatsListener::OnUserStatsStored(UserStatsStored_t *data) {
     if (!lua_checkstack(L, 4)) return;
     lua_rawgeti(L, LUA_REGISTRYINDEX, userStats_ref);
     lua_getfield(L, -1, "onUserStatsStored");
-    if (lua_isnil(L, -1))
+    if (lua_isnil(L, -1)) {
         lua_pop(L, 2);
-    else {
+    } else {
         lua_createtable(L, 0, 3);
         pushuint64(L, data->m_nGameID);
         lua_setfield(L, -2, "gameID");
@@ -210,9 +210,9 @@ void SteamUserStatsListener::OnUserAchievementStored(UserAchievementStored_t *da
     if (!lua_checkstack(L, 4)) return;
     lua_rawgeti(L, LUA_REGISTRYINDEX, userStats_ref);
     lua_getfield(L, -1, "onUserAchievementStored");
-    if (lua_isnil(L, -1))
+    if (lua_isnil(L, -1)) {
         lua_pop(L, 2);
-    else {
+    } else {
         lua_createtable(L, 0, 3);
         pushuint64(L, data->m_nGameID);
         lua_setfield(L, -2, "gameID");
@@ -238,8 +238,9 @@ EXTERN int luasteam_getAchievement(lua_State *L) {
     if (success) {
         lua_pushboolean(L, achieved);
         return 2;
-    } else
+    } else {
         return 1;
+    }
 }
 
 // bool SetAchievement( const char *pchName );
@@ -299,11 +300,11 @@ EXTERN int luasteam_findOrCreateLeaderboard(lua_State *L) {
 EXTERN int luasteam_getLeaderboardDisplayType(lua_State *L) {
     SteamLeaderboard_t leaderboard = checkuint64(L, 1);
     ELeaderboardDisplayType m = SteamUserStats()->GetLeaderboardDisplayType(leaderboard);
-    if (m == k_ELeaderboardDisplayTypeNone)
-
+    if (m == k_ELeaderboardDisplayTypeNone) {
         lua_pushnil(L);
-    else
+    } else {
         lua_pushstring(L, display_types[static_cast<int>(m) - 1]);
+    }
     return 1;
 }
 
@@ -311,10 +312,11 @@ EXTERN int luasteam_getLeaderboardDisplayType(lua_State *L) {
 EXTERN int luasteam_getLeaderboardSortMethod(lua_State *L) {
     SteamLeaderboard_t leaderboard = checkuint64(L, 1);
     ELeaderboardSortMethod m = SteamUserStats()->GetLeaderboardSortMethod(leaderboard);
-    if (m == k_ELeaderboardSortMethodNone)
+    if (m == k_ELeaderboardSortMethodNone) {
         lua_pushnil(L);
-    else
+    } else {
         lua_pushstring(L, sort_methods[static_cast<int>(m) - 1]);
+    }
     return 1;
 }
 
@@ -330,10 +332,11 @@ EXTERN int luasteam_getLeaderboardEntryCount(lua_State *L) {
 EXTERN int luasteam_getLeaderboardName(lua_State *L) {
     SteamLeaderboard_t leaderboard = checkuint64(L, 1);
     const char *name = SteamUserStats()->GetLeaderboardName(leaderboard);
-    if (name == nullptr || *name == '\0')
+    if (name == nullptr || *name == '\0') {
         lua_pushnil(L);
-    else
+    } else {
         lua_pushstring(L, name);
+    }
     return 1;
 }
 
@@ -364,8 +367,9 @@ EXTERN int luasteam_downloadLeaderboardEntries(lua_State *L) {
         start = luaL_checkint(L, 3);
         end = luaL_checkint(L, 4);
         luaL_checktype(L, 5, LUA_TFUNCTION);
-    } else
+    } else {
         luaL_checktype(L, 3, LUA_TFUNCTION);
+    }
     luaL_unref(L, LUA_REGISTRYINDEX, userStats_listener->leaderboardScoresDownloadedCallback_ref);
     userStats_listener->leaderboardScoresDownloadedCallback_ref = luaL_ref(L, LUA_REGISTRYINDEX);
 
@@ -393,9 +397,9 @@ void SteamFriendsListener::OnGameOverlayActivated(GameOverlayActivated_t *data) 
     if (!lua_checkstack(L, 4)) return;
     lua_rawgeti(L, LUA_REGISTRYINDEX, friends_ref);
     lua_getfield(L, -1, "onGameOverlayActivated");
-    if (lua_isnil(L, -1))
+    if (lua_isnil(L, -1)) {
         lua_pop(L, 2);
-    else {
+    } else {
         lua_createtable(L, 0, 1);
         lua_pushboolean(L, data->m_bActive);
         lua_setfield(L, -2, "active");

--- a/luasteam.cxx
+++ b/luasteam.cxx
@@ -35,6 +35,12 @@ const char *sort_methods[] = {"Ascending", "Descending", nullptr};
 const char *display_types[] = {"Numeric", "TimeSeconds", "TimeMilliSeconds", nullptr};
 char tmp_25[25];
 
+SteamLeaderboard_t checkLeaderboard(lua_State *L, int nParam) {
+    uint64 handle = strtoull(luaL_checkstring(L, 1), nullptr, 10);
+    luaL_argcheck(L, handle != 0, 1, "must be a valid handle");
+    return handle;
+}
+
 class SteamUserStatsListener {
   public:
     // LeaderboardFindResult
@@ -134,6 +140,46 @@ EXTERN int luasteam_findOrCreateLeaderboard(lua_State *L) {
     return 0;
 }
 
+// ELeaderboardSortMethod GetLeaderboardSortMethod( SteamLeaderboard_t hSteamLeaderboard );
+EXTERN int luasteam_getLeaderboardDisplayType(lua_State *L) {
+    SteamLeaderboard_t leaderboard = checkLeaderboard(L, 1);
+    ELeaderboardDisplayType m = SteamUserStats()->GetLeaderboardDisplayType(leaderboard);
+    if (m == k_ELeaderboardDisplayTypeNone)
+        lua_pushnil(L);
+    else
+        lua_pushstring(L, display_types[static_cast<int>(m) - 1]);
+    return 1;
+}
+
+// ELeaderboardSortMethod GetLeaderboardSortMethod( SteamLeaderboard_t hSteamLeaderboard );
+EXTERN int luasteam_getLeaderboardSortMethod(lua_State *L) {
+    SteamLeaderboard_t leaderboard = checkLeaderboard(L, 1);
+    ELeaderboardSortMethod m = SteamUserStats()->GetLeaderboardSortMethod(leaderboard);
+    if (m == k_ELeaderboardSortMethodNone)
+        lua_pushnil(L);
+    else
+        lua_pushstring(L, sort_methods[static_cast<int>(m) - 1]);
+    return 1;
+}
+
+// ELeaderboardSortMethod GetLeaderboardSortMethod( SteamLeaderboard_t hSteamLeaderboard );
+EXTERN int luasteam_getLeaderboardEntryCount(lua_State *L) {
+    SteamLeaderboard_t leaderboard = checkLeaderboard(L, 1);
+    int count = SteamUserStats()->GetLeaderboardEntryCount(leaderboard);
+    lua_pushnumber(L, count);
+    return 1;
+}
+
+// ELeaderboardSortMethod GetLeaderboardSortMethod( SteamLeaderboard_t hSteamLeaderboard );
+EXTERN int luasteam_getLeaderboardName(lua_State *L) {
+    SteamLeaderboard_t leaderboard = checkLeaderboard(L, 1);
+    const char *name = SteamUserStats()->GetLeaderboardName(leaderboard);
+    if (name == nullptr || *name == '\0')
+        lua_pushnil(L);
+    else
+        lua_pushstring(L, name);
+    return 1;
+}
 
 // ============================
 // ======= SteamFriends =======
@@ -224,7 +270,7 @@ void add_base(lua_State *L) {
 }
 
 void add_user_stats(lua_State *L) {
-    lua_createtable(L, 0, 7);
+    lua_createtable(L, 0, 11);
     add_func(L, "getAchievement", luasteam_getAchievement);
     add_func(L, "setAchievement", luasteam_setAchievement);
     add_func(L, "resetAllStats", luasteam_resetAllStats);
@@ -232,6 +278,10 @@ void add_user_stats(lua_State *L) {
     add_func(L, "requestCurrentStats", luasteam_requestCurrentStats);
     add_func(L, "findLeaderboard", luasteam_findLeaderboard);
     add_func(L, "findOrCreateLeaderboard", luasteam_findOrCreateLeaderboard);
+    add_func(L, "getLeaderboardEntryCount", luasteam_getLeaderboardEntryCount);
+    add_func(L, "getLeaderboardName", luasteam_getLeaderboardName);
+    add_func(L, "getLeaderboardSortMethod", luasteam_getLeaderboardSortMethod);
+    add_func(L, "getLeaderboardDisplayType", luasteam_getLeaderboardDisplayType);
     lua_pushvalue(L, -1);
     userStats_ref = luaL_ref(L, LUA_REGISTRYINDEX);
     userStats_listener = new SteamUserStatsListener();

--- a/luasteam.cxx
+++ b/luasteam.cxx
@@ -165,9 +165,13 @@ void SteamUserStatsListener::OnLeaderboardScoresDownloaded(LeaderboardScoresDown
 }
 
 void SteamUserStatsListener::OnUserStatsReceived(UserStatsReceived_t *data) {
-    if (data == nullptr) return;
+    if (data == nullptr) {
+        return;
+    }
     lua_State *L = global_lua_state;
-    if (!lua_checkstack(L, 4)) return;
+    if (!lua_checkstack(L, 4)) {
+        return;
+    }
     lua_rawgeti(L, LUA_REGISTRYINDEX, userStats_ref);
     lua_getfield(L, -1, "onUserStatsReceived");
     if (lua_isnil(L, -1)) {
@@ -186,9 +190,13 @@ void SteamUserStatsListener::OnUserStatsReceived(UserStatsReceived_t *data) {
 }
 
 void SteamUserStatsListener::OnUserStatsStored(UserStatsStored_t *data) {
-    if (data == nullptr) return;
+    if (data == nullptr) {
+        return;
+    }
     lua_State *L = global_lua_state;
-    if (!lua_checkstack(L, 4)) return;
+    if (!lua_checkstack(L, 4)) {
+        return;
+    }
     lua_rawgeti(L, LUA_REGISTRYINDEX, userStats_ref);
     lua_getfield(L, -1, "onUserStatsStored");
     if (lua_isnil(L, -1)) {
@@ -205,9 +213,13 @@ void SteamUserStatsListener::OnUserStatsStored(UserStatsStored_t *data) {
 }
 
 void SteamUserStatsListener::OnUserAchievementStored(UserAchievementStored_t *data) {
-    if (data == nullptr) return;
+    if (data == nullptr) {
+        return;
+    }
     lua_State *L = global_lua_state;
-    if (!lua_checkstack(L, 4)) return;
+    if (!lua_checkstack(L, 4)) {
+        return;
+    }
     lua_rawgeti(L, LUA_REGISTRYINDEX, userStats_ref);
     lua_getfield(L, -1, "onUserAchievementStored");
     if (lua_isnil(L, -1)) {
@@ -392,9 +404,13 @@ class SteamFriendsListener {
 };
 
 void SteamFriendsListener::OnGameOverlayActivated(GameOverlayActivated_t *data) {
-    if (data == nullptr) return;
+    if (data == nullptr) {
+        return;
+    }
     lua_State *L = global_lua_state;
-    if (!lua_checkstack(L, 4)) return;
+    if (!lua_checkstack(L, 4)) {
+        return;
+    }
     lua_rawgeti(L, LUA_REGISTRYINDEX, friends_ref);
     lua_getfield(L, -1, "onGameOverlayActivated");
     if (lua_isnil(L, -1)) {

--- a/luasteam.cxx
+++ b/luasteam.cxx
@@ -215,7 +215,7 @@ void SteamUserStatsListener::OnUserAchievementStored(UserAchievementStored_t *da
     if (!lua_checkstack(L, 4))
         return;
     lua_rawgeti(L, LUA_REGISTRYINDEX, userStats_ref);
-    lua_getfield(L, -1, "onUserAchievementsStored");
+    lua_getfield(L, -1, "onUserAchievementStored");
     if (lua_isnil(L, -1))
         lua_pop(L, 2);
     else {

--- a/luasteam.cxx
+++ b/luasteam.cxx
@@ -344,6 +344,14 @@ EXTERN int luasteam_activateGameOverlayToWebPage(lua_State *L) {
     return 0;
 }
 
+// const char * GetFriendPersonaName( CSteamID steamIDFriend );
+EXTERN int luasteam_getFriendPersonaName(lua_State *L) {
+    CSteamID id(checkuint64(L, 1));
+    const char *name = SteamFriends()->GetFriendPersonaName(id);
+    lua_pushstring(L, name);
+    return 1;
+}
+
 // ========================
 // ======= SteamAPI =======
 // ========================
@@ -414,9 +422,10 @@ void add_user_stats(lua_State *L) {
 }
 
 void add_friends(lua_State *L) {
-    lua_createtable(L, 0, 2);
+    lua_createtable(L, 0, 3);
     add_func(L, "activateGameOverlay", luasteam_activateGameOverlay);
     add_func(L, "activateGameOverlayToWebPage", luasteam_activateGameOverlayToWebPage);
+    add_func(L, "getFriendPersonaName", luasteam_getFriendPersonaName);
     lua_pushvalue(L, -1);
     friends_ref = luaL_ref(L, LUA_REGISTRYINDEX);
     friends_listener = new SteamFriendsListener();

--- a/luasteam.cxx
+++ b/luasteam.cxx
@@ -322,7 +322,9 @@ void SteamFriendsListener::OnGameOverlayActivated(GameOverlayActivated_t *data) 
     if (lua_isnil(L, -1)) {
         lua_pop(L, 2);
     } else {
+        lua_createtable(L, 0, 1);
         lua_pushboolean(L, data->m_bActive);
+        lua_setfield(L, -2, "active");
         lua_call(L, 1, 0);
         lua_pop(L, 1);
     }


### PR DESCRIPTION
Added many leaderboard related functions. (They are being used on MarvInc :D)

Added functions:
- init (no longer called automatically)
- findLeaderboard
- findOrCreateLeaderboard
- getLeaderboard(DisplayType/SortMethod/EntryCount/Name)
- uploadLeaderboardScore
- downloadLeaderboardEntries
- activateGameOverlay
- activateGameOverlayToWebPage
- getFriendPersonaName

Callbacks:
- onUserStatsReceived
- onUserStatsStored
- onUserAchievementStored

Other changes:
- Changed onGameOverlayActivatedCallback to make it more similar to the original API
- Removed outdated README stuff. In the next PR (WIP) I'll add proper documentation.