### PR TITLE
Multiple callresults

### DIFF
--- a/src/friends.cpp
+++ b/src/friends.cpp
@@ -6,18 +6,18 @@
 
 namespace {
 
-class SteamFriendsListener;
-SteamFriendsListener *friends_listener = nullptr;
+class CallbackListener;
+CallbackListener *friends_listener = nullptr;
 int friends_ref = LUA_NOREF;
 
 const char *dialog_types[] = {"friends", "community", "players", "settings", "officialgamegroup", "stats", "achievements", NULL};
 
-class SteamFriendsListener {
+class CallbackListener {
   private:
-    STEAM_CALLBACK(SteamFriendsListener, OnGameOverlayActivated, GameOverlayActivated_t);
+    STEAM_CALLBACK(CallbackListener, OnGameOverlayActivated, GameOverlayActivated_t);
 };
 
-void SteamFriendsListener::OnGameOverlayActivated(GameOverlayActivated_t *data) {
+void CallbackListener::OnGameOverlayActivated(GameOverlayActivated_t *data) {
     if (data == nullptr) {
         return;
     }
@@ -74,7 +74,7 @@ void add_friends(lua_State *L) {
     lua_setfield(L, -2, "friends");
 }
 
-void init_friends(lua_State *L) { friends_listener = new SteamFriendsListener(); }
+void init_friends(lua_State *L) { friends_listener = new CallbackListener(); }
 
 void shutdown_friends(lua_State *L) {
     luaL_unref(L, LUA_REGISTRYINDEX, friends_ref);


### PR DESCRIPTION
**Depends on #5**

Before this PR, if you did two calls with callresults at the same time (for example, requesting different leaderboars), one of them wouldn't work. For example:

```lua
Steam.userStats.downloadLeaderboardEntries(lb_handle, "Global", 1, 10000, function(results, err)
    -- Download global stats
end)
Steam.userStats.downloadLeaderboardEntries(lb_handle, "Friends", function(results, err)
    -- Download friends stats
end)
```

This is very useful, like to download multiple entries, or to download data from multiple leaderboards at the same time.

With this PR each call creates its own listener that stores the callback, so it works.