### PR TITLE
More functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@
 ### Sphinx/Docs ###
 /docs/_build
 
+### VSCode ###
+.vscode
+
 ### C++ ###
 # Prerequisites
 *.d

--- a/docs/UGC.rst
+++ b/docs/UGC.rst
@@ -16,6 +16,7 @@ List of Functions
 * :func:`UGC.getSubscribedItems`
 * :func:`UGC.getItemState`
 * :func:`UGC.getItemInstallInfo`
+* :func:`UGC.getItemUpdateProgress`
 * :func:`UGC.startPlaytimeTracking`
 * :func:`UGC.stopPlaytimeTracking`
 * :func:`UGC.stopPlaytimeTrackingForAllItems`
@@ -166,7 +167,7 @@ Function Reference
 
     Uploads the changes made to an item to the Steam Workshop.
 
-    You can track the progress of an item update with :func:`UGC.getItemUpdateProgress` **(mising)**.
+    You can track the progress of an item update with :func:`UGC.getItemUpdateProgress`.
 
     **callback(data, err)** receives two arguments:
 
@@ -265,6 +266,36 @@ Function Reference
     If ``legacyItem`` is set then folder contains the path to the legacy file itself, not a folder.
 
 **Example**:: See :func:`UGC.getSubscribedItems`'s example.
+
+.. function:: UGC.getItemUpdateProgress (handle)
+
+    :param UGCUpdateHandle handle: The update handle to get the progress for.
+    :returns: (`string`) The current status. One of 'Invalid', 'PreparingConfig', 'PreparingContent', 'UploadingContent', 'UploadingPreviewFile', 'CommittingChanges'. See `EItemUpdateStatus <https://partner.steamgames.com/doc/api/ISteamUGC#EItemUpdateStatus>`_.
+    :returns: (`number`) The current number of bytes uploaded.
+    :returns: (`number`) The total number of bytes that will be uploaded.
+    :SteamWorks: `GetItemUpdateProgress <https://partner.steamgames.com/doc/api/ISteamUGC#GetItemUpdateProgress>`_
+
+    Gets the progress of an item update.
+
+**Example**::
+
+    local rev = {
+        PreparingConfig = 0,
+        PreparingContent = 1,
+        UploadingContent = 2,
+        UploadingPreviewFile = 3,
+        CommittingChanges = 4,
+        Invalid = 5, -- also Invalid when the job is finished
+    }
+    local function get_progress(handle)
+        local st, uploaded, total = Steam.UGC.getItemUpdateProgress(handle)
+        local p = rev[st] / 5
+        -- total may be 0 depending on the status
+        if total ~= 0 then
+            p = p + 0.2 * (uploaded / total)
+        end
+        return p
+    end
 
 .. function:: UGC.startPlaytimeTracking (vec, callback)
 

--- a/docs/UGC.rst
+++ b/docs/UGC.rst
@@ -1,0 +1,342 @@
+#########
+ISteamUGC
+#########
+
+List of Functions
+-----------------
+
+* :func:`UGC.createItem`
+* :func:`UGC.startItemUpdate`
+* :func:`UGC.setItemContent`
+* :func:`UGC.setItemDescription`
+* :func:`UGC.setItemPreview`
+* :func:`UGC.setItemTitle`
+* :func:`UGC.submitItemUpdateResult`
+* :func:`UGC.getNumSubscribedItems`
+* :func:`UGC.getSubscribedItems`
+* :func:`UGC.getItemState`
+* :func:`UGC.getItemInstallInfo`
+* :func:`UGC.startPlaytimeTracking`
+* :func:`UGC.stopPlaytimeTracking`
+* :func:`UGC.stopPlaytimeTrackingForAllItems`
+
+Function Reference
+------------------
+
+.. function:: UGC.createItem (consumerAppId, fileType, callback)
+
+    :param number consumerAppId: The App ID that will be using this item.
+    :param string fileType: The type of UGC to create. Must be one of 'Community', 'Microtransaction', 'Collection', 'Art', 'Video', 'Screenshot', 'WebGuide', 'IntegratedGuide', 'Merch', 'ControllerBinding', 'SteamVideo' or 'GameManagedItem' (see `EWorkshopFileType <https://partner.steamgames.com/doc/api/ISteamRemoteStorage#EWorkshopFileType>`_).
+    :param function callback: Called asynchronously when this function returns. See below.
+    :returns: nothing
+    :SteamWorks: `CreateItem <https://partner.steamgames.com/doc/api/ISteamUGC#CreateItem>`_
+
+    Creates a new workshop item with no content attached yet.
+
+    **callback(data, err)** receives two arguments:
+
+    * **data** (`table`) -- Similar to `CreateItemResult_t <https://partner.steamgames.com/doc/api/ISteamUGC#CreateItemResult_t>`_, or **nil** if **err** is **true**.
+
+        * **data.result** (`number`) -- The result of the operation. See `EResult <https://partner.steamgames.com/doc/api/steam_api#EResult>`_.
+
+        * **data.publishedFileId** (`PublishedFileId`) -- The new items unique ID.
+
+        * **data.userNeedsToAcceptWorkshopLegalAgreement** (`boolean`) -- Does the user need to accept the Steam Workshop legal agreement (**true**) or not (**false**)? See the `Workshop Legal Agreement <https://partner.steamgames.com/doc/features/workshop/implementation#Legal>`_ for more information.
+
+    * **err** (`boolean`): **true** if there was any IO error with the request.
+
+**Example**::
+
+    Steam.UGC.createItem(Steam.utils.getAppID(), "Community", function(data, err)
+        if err or data.result ~= 1 then
+            print('Failure when creating item')
+        else
+            populateItem(data.publishedFileId)
+        end
+    end)
+
+.. function:: UGC.startItemUpdate (consumerAppId, publishedFileId)
+
+    :param number consumerAppId: The App ID that will be using this item.
+    :param PublishedFileId publishedFileId: The item to update.
+    :returns: (`UGCUpdateHandle`) A handle that you can use with future calls to modify the item before finally sending the update.
+    :SteamWorks: `StartItemUpdate <https://partner.steamgames.com/doc/api/ISteamUGC#StartItemUpdate>`_
+
+    Starts the item update process.
+
+    This gets you a handle that you can use to modify the item before finally sending off the update to the server with :func:`UGC.submitItemUpdate`.
+
+**Example**::
+
+    local function populateItem(id)
+        local handle = Steam.UGC.startItemUpdate(Steam.utils.getAppID(), id)
+        Steam.UGC.setItemContent(handle, rootFolder)
+        Steam.UGC.setItemTitle(handle, "My Item")
+        Steam.UGC.setItemDescription(handle, "A Workshop item")
+        Steam.UGC.setItemPreview(handle, rootFolder .. '/preview.png')
+        Steam.UGC.submitItemUpdate(handle, "First Revision", function(data, err)
+            if err or data.result ~= 1 then
+                print('Update failed')
+            else
+                print('Update successfull')
+            end
+        end)
+    end
+
+.. function:: UGC.setItemContent (handle, contentFolder)
+
+    :param UGCUpdateHandle handle: The workshop item update handle to customize.
+    :param string contentFolder: The absolute path to a local folder containing the content for the item.
+    :returns: (`boolean`) **true** upon success. **false** if the UGC update handle is invalid.
+    :SteamWorks: `SetItemContent <https://partner.steamgames.com/doc/api/ISteamUGC#SetItemContent>`_
+
+    Sets the folder that will be stored as the content for an item.
+
+    For efficient upload and download, files should not be merged or compressed into single files (e.g. zip files).
+
+    .. note::
+
+        This must be set before you submit the UGC update handle using :func:`UGC.submitItemUpdate`.
+
+
+**Example**:: See :func:`UGC.startItemUpdate`'s example.
+
+.. function:: UGC.setItemDescription (handle, description)
+
+    :param UGCUpdateHandle handle: The workshop item update handle to customize.
+    :param string description: The new description of the item.
+    :returns: (`boolean`) **true** upon success. **false** if the UGC update handle is invalid.
+    :SteamWorks: `SetItemDescription <https://partner.steamgames.com/doc/api/ISteamUGC#SetItemDescription>`_
+
+    Sets a new description for an item.
+
+    The description must be limited to the length defined by `k_cchPublishedDocumentDescriptionMax <https://partner.steamgames.com/doc/api/ISteamRemoteStorage#k_cchPublishedDocumentDescriptionMax>`_.
+
+    You can set what language this is for by using :func:`UGC.setItemUpdateLanguage` **(missing)**, if no language is set then "english" is assumed.
+
+    .. note::
+    
+        This must be set before you submit the UGC update handle using :func:`UGC.submitItemUpdate`.
+
+**Example**:: See :func:`UGC.startItemUpdate`'s example.
+
+.. function:: UGC.setItemPreview (handle, previewFile)
+
+    :param UGCUpdateHandle handle: The workshop item update handle to customize.
+    :param string previewFile: The absolute path to a local preview image file for the item.
+    :returns: **true** upon success. **false** if the UGC update handle is invalid.
+    :SteamWorks: `SetItemPreview <https://partner.steamgames.com/doc/api/ISteamUGC#SetItemPreview>`_
+
+    Sets the primary preview image for the item.
+
+    The format should be one that both the web and the application (if necessary) can render. Suggested formats include JPG, PNG and GIF.
+
+    .. note::
+    
+        This must be set before you submit the UGC update handle using :func:`UGC.submitItemUpdate`.
+
+**Example**:: See :func:`UGC.startItemUpdate`'s example.
+
+.. function:: UGC.setItemTitle (handle, title)
+
+    :param UGCUpdateHandle handle: The workshop item update handle to customize.
+    :param string title: The new title of the item.
+    :returns: (`boolean`) **true** upon success. **false** if the UGC update handle is invalid.
+    :SteamWorks: `SetItemTitle <https://partner.steamgames.com/doc/api/ISteamUGC#SetItemTitle>`_
+
+    Sets a new title for an item.
+
+    The title must be limited to the size defined by `k_cchPublishedDocumentTitleMax <https://partner.steamgames.com/doc/api/ISteamRemoteStorage#k_cchPublishedDocumentTitleMax>`_.
+
+    You can set what language this is for by using :func:`UGC.setItemUpdateLanguage`, if no language is set then "english" is assumed.
+
+    .. note::
+    
+        This must be set before you submit the UGC update handle using :func:`UGC.submitItemUpdate`.
+
+**Example**:: See :func:`UGC.startItemUpdate`'s example.
+
+.. function:: UGC.submitItemUpdate (handle, changeNote, callback)
+
+    :param UGCUpdateHandle handle: The update handle to submit.
+    :param string? changeNote: A brief description of the changes made (Optional, set to **nil** for no change note).
+    :param function callback: Called asynchronously when this function returns. See below.
+    :returns: nothing
+    :SteamWorks: `SubmitItemUpdateResult <https://partner.steamgames.com/doc/api/ISteamUGC#SubmitItemUpdate>`_
+
+    Uploads the changes made to an item to the Steam Workshop.
+
+    You can track the progress of an item update with :func:`UGC.getItemUpdateProgress` **(mising)**.
+
+    **callback(data, err)** receives two arguments:
+
+    * **data** (`table`) -- Similar to `SubmitItemUpdateResult_t <https://partner.steamgames.com/doc/api/ISteamUGC#SubmitItemUpdateResult_t>`_, or **nil** if **err** is **true**.
+
+        * **data.result** (`number`) -- The result of the operation. See `EResult <https://partner.steamgames.com/doc/api/steam_api#EResult>`_.
+
+        * **data.userNeedsToAcceptWorkshopLegalAgreement** (`boolean`) -- Does the user need to accept the Steam Workshop legal agreement (**true**) or not (**false**)? See the `Workshop Legal Agreement <https://partner.steamgames.com/doc/features/workshop/implementation#Legal>`_ for more information.
+
+    * **err** (`boolean`): **true** if there was any IO error with the request.
+
+**Example**:: See :func:`UGC.startItemUpdate`'s example.
+
+.. function:: UGC.getNumSubscribedItems ()
+
+    :returns: (`number`) Total number of subscribed items. **0** if called from a game server.
+    :SteamWorks: `GetNumSubscribedItems <https://partner.steamgames.com/doc/api/ISteamUGC#GetNumSubscribedItems>`_
+
+    Gets the total number of items the current user is subscribed to for the game or application.
+
+**Example**::
+
+    print('You are subscribed to ' .. Steam.UGC.getNumSubscribedItems() .. ' items')
+
+.. function:: UGC.getSubscribedItems ()
+
+    :returns: (`table`) An array of `PublishedFileId` for all your subscribed items. Empty if called from a game server.
+    :SteamWorks: `GetSubscribedItems <https://partner.steamgames.com/doc/api/ISteamUGC#GetSubscribedItems>`_
+
+    Gets a list of all of the items the current user is subscribed to for the current game.
+
+.. warning::
+    
+    This function is slightly different from the SteamWorks API. You don't need to send the array, it is returned by the function.
+
+**Example**::
+
+    for _, id in ipairs(Steam.UGC.getSubscribedItems()) do
+        local flag = Steam.UGC.getItemState(id)
+        if flag.installed then
+            print('Subscribed item is installed!')
+            local success, sizeOnDisk, folder = Steam.UGC.getItemInstallInfo(id)
+            print('Install location: ' .. folder)
+            print('Install size: ' .. sizeOnDisk)
+        elseif flag.downloading then
+            print('Subscribed item is downloading!')
+        else
+            print('Subscribed item is doing something')
+        end
+    end
+
+.. function:: UGC.getItemState (id)
+
+    :param PublishedFileId id: The workshop item to get the state for.
+    :returns: (`table`) A table with flags for the item state, or nil if the item is not tracked on client. All flags are boolean values.
+
+        * **subscribed** -- The current user is subscribed to this item. Not just cached.
+
+        * **legacyItem** -- The item was created with the old workshop functions in ISteamRemoteStorage.
+
+        * **installed** -- Item is installed and usable (but maybe out of date).
+
+        * **needsUpdate** -- The items needs an update. Either because it's not installed yet or creator updated the content.
+
+        * **downloading** -- The item update is currently downloading.
+
+        * **downloadPending** -- :func:`UGC.downloadItem` **(missing)** was called for this item, the content isn't available until the callback is fired.
+
+    :SteamWorks: `GetItemState <https://partner.steamgames.com/doc/api/ISteamUGC#GetItemState>`_
+
+    Gets the current state of a workshop item on this client.
+
+**Example**:: See :func:`UGC.getSubscribedItems`'s example.
+
+.. function:: UGC.getItemInstallInfo (id)
+
+    :returns: (`boolean`) **true** if the operation is successfull. **false** in the following cases:
+
+    * cchFolderSize is 0.
+
+    * The workshop item has no content.
+
+    * The workshop item is not installed.
+
+    If this value is **false**, nothing else is returned. Otherwise:
+
+    :returns: (`number`) Returns the size of the workshop item in bytes.
+    :returns: (`string`) Returns the absolute path to the folder containing the content.
+    :returns: (`number`) Returns the time when the workshop item was last updated.
+    :SteamWorks: `GetItemInstallInfo <https://partner.steamgames.com/doc/api/ISteamUGC#GetItemInstallInfo>`_
+
+    Gets info about currently installed content on the disc for workshop items that have ``installed`` set.
+
+    Calling this sets the "used" flag on the workshop item for the current player and adds it to their ``usedOrPlayed`` list.
+
+    If ``legacyItem`` is set then folder contains the path to the legacy file itself, not a folder.
+
+**Example**:: See :func:`UGC.getSubscribedItems`'s example.
+
+.. function:: UGC.startPlaytimeTracking (vec, callback)
+
+    :param table vec: The array of workshop items (`PublishedFileId`) you want to start tracking. (Maximum of 100 items.)
+    :param function callback: Called asynchronously when this function returns. It is only called if you send between 1 and 100 items. See below.
+    :returns: nothing
+    :SteamWorks: `StartPlaytimeTracking <https://partner.steamgames.com/doc/api/ISteamUGC#StartPlaytimeTracking>`_
+
+    Start tracking playtime on a set of workshop items.
+
+    When your app shuts down, playtime tracking will automatically stop.
+    **callback(data, err)** receives two arguments:
+
+    * **data** (`table`) -- Similar to `StartPlaytimeTrackingResult_t <https://partner.steamgames.com/doc/api/ISteamUGC#StartPlaytimeTrackingResult_t>`_, or **nil** if **err** is **true**.
+
+        * **data.result** (`number`) -- The result of the operation. See `EResult <https://partner.steamgames.com/doc/api/steam_api#EResult>`_.
+
+    * **err** (`boolean`): **true** if there was any IO error with the request.
+
+**Example**::
+
+    -- Tracks all subscribed items (you probably shouldn't do this)
+    Steam.UGC.startPlaytimeTracking(Steam.UGC.getSubscribedItems(), function(data, err)
+        if not err and data.result == 1 then
+            print('Tracking succeded')
+        end
+    end)
+
+.. function:: UGC.stopPlaytimeTracking (vec, callback)
+
+    :param table vec: The array of workshop items (`PublishedFileId`) you want to stop tracking. (Maximum of 100 items.)
+    :param function callback: Called asynchronously when this function returns. It is only called if you send between 1 and 100 items. See below.
+    :returns: nothing
+    :SteamWorks: `StopPlaytimeTracking <https://partner.steamgames.com/doc/api/ISteamUGC#StopPlaytimeTracking>`_
+
+    Stop tracking playtime on a set of workshop items.
+
+    When your app shuts down, playtime tracking will automatically stop.
+
+    **callback(data, err)** receives two arguments:
+
+    * **data** (`table`) -- Similar to `StopPlaytimeTrackingResult_t <https://partner.steamgames.com/doc/api/ISteamUGC#StopPlaytimeTrackingResult_t>`_, or **nil** if **err** is **true**.
+
+        * **data.result** (`number`) -- The result of the operation. See `EResult <https://partner.steamgames.com/doc/api/steam_api#EResult>`_.
+
+    * **err** (`boolean`): **true** if there was any IO error with the request.
+
+**Example**::
+
+    local function stopTracking(...)
+        Steam.UGC.stopPlaytimeTracking({...}, function(data, err)
+            if not err and data.result == 1 then
+                print('Tracking successfully stopped')
+            end
+        end)
+    end
+
+
+.. function:: UGC.stopPlaytimeTrackingForAllItems (callback)
+
+    :param function callback: Called asynchronously when this function returns. It must be of the same type as the callback in :func:`UGC.stopPlaytimeTracking`.
+    :returns: nothing
+    :SteamWorks: `StopPlaytimeTracking <https://partner.steamgames.com/doc/api/ISteamUGC#StopPlaytimeTracking>`_
+
+    Stop tracking playtime of all workshop items.
+
+    When your app shuts down, playtime tracking will automatically stop.
+
+**Example**::
+
+    Steam.UGC.stopPlaytimeTrackingForAllItems(function(data, err)
+        if not err and data.result == 1 then
+            print('Tracking successfully stopped for all items')
+        end
+    end)

--- a/docs/UGC.rst
+++ b/docs/UGC.rst
@@ -40,7 +40,7 @@ Function Reference
 
         * **data.result** (`number`) -- The result of the operation. See `EResult <https://partner.steamgames.com/doc/api/steam_api#EResult>`_.
 
-        * **data.publishedFileId** (`PublishedFileId`) -- The new items unique ID.
+        * **data.publishedFileId** (`uint64`) -- The new items unique ID.
 
         * **data.userNeedsToAcceptWorkshopLegalAgreement** (`boolean`) -- Does the user need to accept the Steam Workshop legal agreement (**true**) or not (**false**)? See the `Workshop Legal Agreement <https://partner.steamgames.com/doc/features/workshop/implementation#Legal>`_ for more information.
 
@@ -59,8 +59,8 @@ Function Reference
 .. function:: UGC.startItemUpdate (consumerAppId, publishedFileId)
 
     :param number consumerAppId: The App ID that will be using this item.
-    :param PublishedFileId publishedFileId: The item to update.
-    :returns: (`UGCUpdateHandle`) A handle that you can use with future calls to modify the item before finally sending the update.
+    :param uint64 publishedFileId: The item to update.
+    :returns: (`uint64`) A handle that you can use with future calls to modify the item before finally sending the update.
     :SteamWorks: `StartItemUpdate <https://partner.steamgames.com/doc/api/ISteamUGC#StartItemUpdate>`_
 
     Starts the item update process.
@@ -84,9 +84,9 @@ Function Reference
         end)
     end
 
-.. function:: UGC.setItemContent (handle, contentFolder)
+.. function:: UGC.setItemContent (updateHandle, contentFolder)
 
-    :param UGCUpdateHandle handle: The workshop item update handle to customize.
+    :param uint64 updateHandle: The workshop item update handle to customize.
     :param string contentFolder: The absolute path to a local folder containing the content for the item.
     :returns: (`boolean`) **true** upon success. **false** if the UGC update handle is invalid.
     :SteamWorks: `SetItemContent <https://partner.steamgames.com/doc/api/ISteamUGC#SetItemContent>`_
@@ -102,9 +102,9 @@ Function Reference
 
 **Example**:: See :func:`UGC.startItemUpdate`'s example.
 
-.. function:: UGC.setItemDescription (handle, description)
+.. function:: UGC.setItemDescription (updateHandle, description)
 
-    :param UGCUpdateHandle handle: The workshop item update handle to customize.
+    :param uint64 updateHandle: The workshop item update handle to customize.
     :param string description: The new description of the item.
     :returns: (`boolean`) **true** upon success. **false** if the UGC update handle is invalid.
     :SteamWorks: `SetItemDescription <https://partner.steamgames.com/doc/api/ISteamUGC#SetItemDescription>`_
@@ -116,14 +116,14 @@ Function Reference
     You can set what language this is for by using :func:`UGC.setItemUpdateLanguage` **(missing)**, if no language is set then "english" is assumed.
 
     .. note::
-    
+
         This must be set before you submit the UGC update handle using :func:`UGC.submitItemUpdate`.
 
 **Example**:: See :func:`UGC.startItemUpdate`'s example.
 
-.. function:: UGC.setItemPreview (handle, previewFile)
+.. function:: UGC.setItemPreview (updateHandle, previewFile)
 
-    :param UGCUpdateHandle handle: The workshop item update handle to customize.
+    :param uint64 updateHandle: The workshop item update handle to customize.
     :param string previewFile: The absolute path to a local preview image file for the item.
     :returns: **true** upon success. **false** if the UGC update handle is invalid.
     :SteamWorks: `SetItemPreview <https://partner.steamgames.com/doc/api/ISteamUGC#SetItemPreview>`_
@@ -133,14 +133,14 @@ Function Reference
     The format should be one that both the web and the application (if necessary) can render. Suggested formats include JPG, PNG and GIF.
 
     .. note::
-    
+
         This must be set before you submit the UGC update handle using :func:`UGC.submitItemUpdate`.
 
 **Example**:: See :func:`UGC.startItemUpdate`'s example.
 
-.. function:: UGC.setItemTitle (handle, title)
+.. function:: UGC.setItemTitle (updateHandle, title)
 
-    :param UGCUpdateHandle handle: The workshop item update handle to customize.
+    :param uint64 updateHandle: The workshop item update handle to customize.
     :param string title: The new title of the item.
     :returns: (`boolean`) **true** upon success. **false** if the UGC update handle is invalid.
     :SteamWorks: `SetItemTitle <https://partner.steamgames.com/doc/api/ISteamUGC#SetItemTitle>`_
@@ -152,14 +152,14 @@ Function Reference
     You can set what language this is for by using :func:`UGC.setItemUpdateLanguage`, if no language is set then "english" is assumed.
 
     .. note::
-    
+
         This must be set before you submit the UGC update handle using :func:`UGC.submitItemUpdate`.
 
 **Example**:: See :func:`UGC.startItemUpdate`'s example.
 
-.. function:: UGC.submitItemUpdate (handle, changeNote, callback)
+.. function:: UGC.submitItemUpdate (updateHandle, changeNote, callback)
 
-    :param UGCUpdateHandle handle: The update handle to submit.
+    :param uint64 updateHandle: The update handle to submit.
     :param string? changeNote: A brief description of the changes made (Optional, set to **nil** for no change note).
     :param function callback: Called asynchronously when this function returns. See below.
     :returns: nothing
@@ -194,13 +194,13 @@ Function Reference
 
 .. function:: UGC.getSubscribedItems ()
 
-    :returns: (`table`) An array of `PublishedFileId` for all your subscribed items. Empty if called from a game server.
+    :returns: (`table`) An array of `PublishedFileId` (more precisely, `uint64`) for all your subscribed items. Empty if called from a game server.
     :SteamWorks: `GetSubscribedItems <https://partner.steamgames.com/doc/api/ISteamUGC#GetSubscribedItems>`_
 
     Gets a list of all of the items the current user is subscribed to for the current game.
 
 .. warning::
-    
+
     This function is slightly different from the SteamWorks API. You don't need to send the array, it is returned by the function.
 
 **Example**::
@@ -219,9 +219,9 @@ Function Reference
         end
     end
 
-.. function:: UGC.getItemState (id)
+.. function:: UGC.getItemState (publishedFileId)
 
-    :param PublishedFileId id: The workshop item to get the state for.
+    :param uint64 publishedFileId: The workshop item to get the state for.
     :returns: (`table`) A table with flags for the item state, or nil if the item is not tracked on client. All flags are boolean values.
 
         * **subscribed** -- The current user is subscribed to this item. Not just cached.
@@ -246,13 +246,13 @@ Function Reference
 
     :returns: (`boolean`) **true** if the operation is successfull. **false** in the following cases:
 
-    * cchFolderSize is 0.
+        * cchFolderSize is 0.
 
-    * The workshop item has no content.
+        * The workshop item has no content.
 
-    * The workshop item is not installed.
+        * The workshop item is not installed.
 
-    If this value is **false**, nothing else is returned. Otherwise:
+        If this value is **false**, nothing else is returned. Otherwise:
 
     :returns: (`number`) Returns the size of the workshop item in bytes.
     :returns: (`string`) Returns the absolute path to the folder containing the content.
@@ -269,7 +269,7 @@ Function Reference
 
 .. function:: UGC.getItemUpdateProgress (handle)
 
-    :param UGCUpdateHandle handle: The update handle to get the progress for.
+    :param uint64 handle: The update handle to get the progress for.
     :returns: (`string`) The current status. One of 'Invalid', 'PreparingConfig', 'PreparingContent', 'UploadingContent', 'UploadingPreviewFile', 'CommittingChanges'. See `EItemUpdateStatus <https://partner.steamgames.com/doc/api/ISteamUGC#EItemUpdateStatus>`_.
     :returns: (`number`) The current number of bytes uploaded.
     :returns: (`number`) The total number of bytes that will be uploaded.
@@ -299,7 +299,7 @@ Function Reference
 
 .. function:: UGC.startPlaytimeTracking (vec, callback)
 
-    :param table vec: The array of workshop items (`PublishedFileId`) you want to start tracking. (Maximum of 100 items.)
+    :param table vec: The array of workshop items (`PublishedFileId`, more precisely `uint64`) you want to start tracking. (Maximum of 100 items.)
     :param function callback: Called asynchronously when this function returns. It is only called if you send between 1 and 100 items. See below.
     :returns: nothing
     :SteamWorks: `StartPlaytimeTracking <https://partner.steamgames.com/doc/api/ISteamUGC#StartPlaytimeTracking>`_
@@ -326,7 +326,7 @@ Function Reference
 
 .. function:: UGC.stopPlaytimeTracking (vec, callback)
 
-    :param table vec: The array of workshop items (`PublishedFileId`) you want to stop tracking. (Maximum of 100 items.)
+    :param table vec: The array of workshop items (`PublishedFileId`, more precisely `uint64`) you want to stop tracking. (Maximum of 100 items.)
     :param function callback: Called asynchronously when this function returns. It is only called if you send between 1 and 100 items. See below.
     :returns: nothing
     :SteamWorks: `StopPlaytimeTracking <https://partner.steamgames.com/doc/api/ISteamUGC#StopPlaytimeTracking>`_

--- a/docs/extra.rst
+++ b/docs/extra.rst
@@ -1,0 +1,32 @@
+#####
+Extra
+#####
+
+This module has some extra functions that are not in the SteamWorks API but may be useful to deal with it.
+
+List of Functions
+-----------------
+
+* :func:`extra.parseUint64`
+
+Function Reference
+------------------
+
+.. function:: extra.parseUint64 (str)
+
+    :param string str: The string to convert to uint64.
+    :returns: (`uint64`) The parsed number. 0 if the string was invalid.
+    :see: :ref:`64-bit-integers`
+
+    Converts a string to a 64-bit integer that can be used with this library.
+
+**Example**::
+
+    local function saveMyId()
+        -- This is highly useless since your ID won't change, but you get the point.
+        writeFile('my_id.txt', tostring(Steam.user.getSteamID()))
+    end
+
+    local function readMyId()
+        return Steam.extra.parseUint64(readFile('my_id.txt'))
+    end

--- a/docs/friends.rst
+++ b/docs/friends.rst
@@ -45,7 +45,7 @@ Function Reference
 
 .. function:: friends.getFriendPersonaName(steam_id)
 
-    :param steam_id: The Steam ID of the other user.
+    :param steamID steam_id: The Steam ID of the other user.
     :returns: (`string`) The current users persona name. Returns an empty string (""), or "[unknown]" if the Steam ID is invalid or not known to the caller.
     :SteamWorks: `GetFriendPersonaName <https://partner.steamgames.com/doc/api/ISteamFriends#GetFriendPersonaName>`_
 

--- a/docs/friends.rst
+++ b/docs/friends.rst
@@ -45,7 +45,7 @@ Function Reference
 
 .. function:: friends.getFriendPersonaName(steam_id)
 
-    :param steamID steam_id: The Steam ID of the other user.
+    :param uint64 steam_id: The Steam ID of the other user.
     :returns: (`string`) The current users persona name. Returns an empty string (""), or "[unknown]" if the Steam ID is invalid or not known to the caller.
     :SteamWorks: `GetFriendPersonaName <https://partner.steamgames.com/doc/api/ISteamFriends#GetFriendPersonaName>`_
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -151,3 +151,24 @@ Code in luasteam
 .. warning::
 
     To use Callbacks and Call Results, you **must** constantly call ``Steam.runCallbacks()``, preferably in your game loop.
+
+.. _64-bit-integers:
+
+64-bit integers
+---------------
+
+Some identifiers in the SteamWorks API are 64-bit integers (for example, SteamID, Leaderboard Handle, etc.).
+In this documentation, these use `uint64` types instead of `number`.
+
+Since Lua 5.1 does not support integers, and doubles (the default number type) can't hold a 64-bit integer with no error, we use userdata to keep such integers (even in Lua versions that support integers).
+
+They can only be compared for equality or converted to strings (using the `tostring` function), since doing any math on them doesn't make any sense. You can use :func:`extra.parseUint64` to parse them from strings.
+
+::
+
+    local original = Steam.user.getSteamID()
+    local str = tostring(original)
+    print("Your id is " .. str)
+    local id = Steam.extra.parseUint64(str)
+    -- equality works, even though they are different userdata instances
+    assert(id == original)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,6 +22,7 @@ While using this documentation, you may also like to check the `SteamWorks API R
     ISteamUser <user>
     ISteamUserStats <user_stats>
     ISteamUtils <utils>
+    ISteamUGC <UGC>
 
 Indices and tables
 ==================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,6 +23,7 @@ While using this documentation, you may also like to check the `SteamWorks API R
     ISteamUserStats <user_stats>
     ISteamUtils <utils>
     ISteamUGC <UGC>
+    Extra <extra>
 
 Indices and tables
 ==================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,6 +19,7 @@ While using this documentation, you may also like to check the `SteamWorks API R
     Getting Started <getting_started>
     Core Functions <steam_api>
     ISteamFriends <friends>
+    ISteamUser <user>
     ISteamUserStats <user_stats>
 
 Indices and tables

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,6 +21,7 @@ While using this documentation, you may also like to check the `SteamWorks API R
     ISteamFriends <friends>
     ISteamUser <user>
     ISteamUserStats <user_stats>
+    ISteamUtils <utils>
 
 Indices and tables
 ==================

--- a/docs/user.rst
+++ b/docs/user.rst
@@ -1,0 +1,42 @@
+##########
+ISteamUser
+##########
+
+List of Functions
+-----------------
+
+* :func:`user.getPlayerSteamLevel`
+* :func:`user.getSteamID`
+
+
+Function Reference
+------------------
+
+.. function:: user.getPlayerSteamLevel ()
+
+    :returns: (`number`) The level of the current user.
+    :SteamWorks: `GetPlayerSteamLevel <https://partner.steamgames.com/doc/api/ISteamUser#GetPlayerSteamLevel>`_
+
+    Gets the Steam level of the user, as shown on their Steam community profile.
+
+**Example**::
+
+    print('Let me show you some magic')
+    print('Your Steam Level is...')
+    print(Steam.user.getPlayerSteamLevel() .. '!!!')
+
+.. function:: user.getSteamID ()
+
+    :returns: (`steamID`) The SteamID of the current user.
+    :SteamWorks: `GetSteamID <https://partner.steamgames.com/doc/api/ISteamUser#GetSteamID>`_
+
+    Gets the Steam ID of the account currently logged into the Steam client. This is commonly called the 'current user', or 'local user'.
+
+    A Steam ID is a unique identifier for a Steam accounts, Steam groups, Lobbies and Chat rooms, and used to differentiate users in all parts of the Steamworks API.
+
+**Example**::
+
+    local my_id = Steam.user.getSteamID()
+    function isSteamIDFromUser(steam_id)
+        return steam_id == my_id
+    end

--- a/docs/user.rst
+++ b/docs/user.rst
@@ -27,7 +27,7 @@ Function Reference
 
 .. function:: user.getSteamID ()
 
-    :returns: (`steamID`) The SteamID of the current user.
+    :returns: (`uint64`) The SteamID of the current user.
     :SteamWorks: `GetSteamID <https://partner.steamgames.com/doc/api/ISteamUser#GetSteamID>`_
 
     Gets the Steam ID of the account currently logged into the Steam client. This is commonly called the 'current user', or 'local user'.

--- a/docs/user_stats.rst
+++ b/docs/user_stats.rst
@@ -155,7 +155,7 @@ Function Reference
 
     **callback(data, err)** receives two arguments:
 
-    * **data** (`table`) -- Similar to `LeaderboardFindResult_t <https://partner.steamgames.com/doc/api/ISteamUserStats#LeaderboardFindResult_t>`_, or **nil** if there was **err** is **true**.
+    * **data** (`table`) -- Similar to `LeaderboardFindResult_t <https://partner.steamgames.com/doc/api/ISteamUserStats#LeaderboardFindResult_t>`_, or **nil** if **err** is **true**.
 
         * **data.steamLeaderboard** (`leaderboard`) -- Handle to the leaderboard that was searched for. A special value is returned if no leaderboard was found.
 

--- a/docs/user_stats.rst
+++ b/docs/user_stats.rst
@@ -157,7 +157,7 @@ Function Reference
 
     * **data** (`table`) -- Similar to `LeaderboardFindResult_t <https://partner.steamgames.com/doc/api/ISteamUserStats#LeaderboardFindResult_t>`_, or **nil** if **err** is **true**.
 
-        * **data.steamLeaderboard** (`leaderboard`) -- Handle to the leaderboard that was searched for. A special value is returned if no leaderboard was found.
+        * **data.steamLeaderboard** (`uint64`) -- Handle to the leaderboard that was searched for. A special value is returned if no leaderboard was found.
 
         * **data.leaderboardFound** (`boolean`) -- Was the leaderboard found? **true** if it was, **false** if it wasn't.
 
@@ -201,7 +201,7 @@ Function Reference
 
 .. function:: userStats.getLeaderboardName(steamLeaderboard)
 
-    :param leaderboard steamLeaderboard: A leaderboard handle obtained from :func:`userStats.findLeaderboard` or :func:`userStats.findOrCreateLeaderboard`.
+    :param uint64 steamLeaderboard: A leaderboard handle obtained from :func:`userStats.findLeaderboard` or :func:`userStats.findOrCreateLeaderboard`.
     :returns: (`string`) The name of the leaderboard. Returns an empty string if the leaderboard handle is invalid.
     :SteamWorks: `GetLeaderboardName <https://partner.steamgames.com/doc/api/ISteamUserStats#GetLeaderboardName>`_
 
@@ -218,7 +218,7 @@ Function Reference
 
 .. function:: userStats.getLeaderboardEntryCount(steamLeaderboard)
 
-    :param leaderboard steamLeaderboard: A leaderboard handle obtained from :func:`userStats.findLeaderboard` or :func:`userStats.findOrCreateLeaderboard`.
+    :param uint64 steamLeaderboard: A leaderboard handle obtained from :func:`userStats.findLeaderboard` or :func:`userStats.findOrCreateLeaderboard`.
     :returns: (`number`) The number of entries in the leaderboard. Returns 0 if the leaderboard handle is invalid.
     :SteamWorks: `GetLeaderboardEntryCount <https://partner.steamgames.com/doc/api/ISteamUserStats#GetLeaderboardEntryCount>`_
 
@@ -230,7 +230,7 @@ Function Reference
 
 .. function:: userStats.getLeaderboardSortMethod(steamLeaderboard)
 
-    :param leaderboard steamLeaderboard: A leaderboard handle obtained from :func:`userStats.findLeaderboard` or :func:`userStats.findOrCreateLeaderboard`.
+    :param uint64 steamLeaderboard: A leaderboard handle obtained from :func:`userStats.findLeaderboard` or :func:`userStats.findOrCreateLeaderboard`.
     :returns: (`string?`) The sort method of the leaderboard, either "Ascending" or "Descending". Returns **nil** if the leaderboard handle is invalid.
     :SteamWorks: `GetLeaderboardSortMethod <https://partner.steamgames.com/doc/api/ISteamUserStats#GetLeaderboardSortMethod>`_
 
@@ -240,7 +240,7 @@ Function Reference
 
 .. function:: userStats.getLeaderboardDisplayType(steamLeaderboard)
 
-    :param leaderboard steamLeaderboard: A leaderboard handle obtained from :func:`userStats.findLeaderboard` or :func:`userStats.findOrCreateLeaderboard`.
+    :param uint64 steamLeaderboard: A leaderboard handle obtained from :func:`userStats.findLeaderboard` or :func:`userStats.findOrCreateLeaderboard`.
     :returns: (`string?`) The display type of the leaderboard, one of "Numeric", "TimeSeconds" or "TimeMilliSeconds". Returns **nil** if the leaderboard handle is invalid.
     :SteamWorks: `GetLeaderboardDisplayType <https://partner.steamgames.com/doc/api/ISteamUserStats#GetLeaderboardDisplayType>`_
 
@@ -250,7 +250,7 @@ Function Reference
 
 .. function:: userStats.uploadLeaderboardScore(steamLeaderboard, uploadScoreMethod, score, details, callback)
 
-    :param leaderboard steamLeaderboard: A leaderboard handle obtained from :func:`userStats.findLeaderboard` or :func:`userStats.findOrCreateLeaderboard`.
+    :param uint64 steamLeaderboard: A leaderboard handle obtained from :func:`userStats.findLeaderboard` or :func:`userStats.findOrCreateLeaderboard`.
     :param string uploadScoreMethod: Do you want to force the score to change, or keep the previous score if it was better? Either "KeepBest" or "ForceUpdate".
     :param number score: The score to upload. Must be a 32-bit integer.
     :param string? details: Optional string with details surrounding the unlocking of this score. Size must be a multiple of four, and at most 256 bytes. Will be converted to an array of 32-bit integers.
@@ -274,7 +274,7 @@ Function Reference
 
             * The leaderboard is set to "Trusted" in App Admin on Steamworks website, and will only accept scores sent from the Steam Web API.
         
-        * **data.steamLeaderboard** (`leaderboard`) -- Handle to the leaderboard that was searched for. A special value is returned if no leaderboard was found.
+        * **data.steamLeaderboard** (`uint64`) -- Handle to the leaderboard that was searched for. A special value is returned if no leaderboard was found.
 
         * **data.score** (`number`) -- The score that was attempted to set.
 
@@ -302,7 +302,7 @@ Function Reference
 .. function:: userStats.downloadLeaderboardEntries(steamLeaderboard, dataRequest, rangeStart, rangeEnd, callback)
               userStats.downloadLeaderboardEntries(steamLeaderboard, dataRequest, callback)
 
-    :param leaderboard steamLeaderboard: A leaderboard handle obtained from :func:`userStats.findLeaderboard` or :func:`userStats.findOrCreateLeaderboard`.
+    :param uint64 steamLeaderboard: A leaderboard handle obtained from :func:`userStats.findLeaderboard` or :func:`userStats.findOrCreateLeaderboard`.
     :param string dataRequest: The type of data request to make. Must be one of "Global", "GlobalAroundUser" or "Friends" (see `ELeaderboardDataRequest <https://partner.steamgames.com/doc/api/ISteamUserStats#ELeaderboardDataRequest>`_).
     :param number rangeStart: The index to start downloading entries relative to **dataRequest**. Must **not** be supplied if **dataRequest** is "Friends".
     :param number rangeEnd: The last index to retrieve entries relative to **dataRequest**. Must **not** be supplied if **dataRequest** is "Friends".
@@ -320,7 +320,7 @@ Function Reference
 
     * **data** (`table`) -- An array of tables similar to `LeaderboardEntry_t <https://partner.steamgames.com/doc/api/ISteamUserStats#LeaderboardEntry_t>`_, or **nil** if there was **err** is **true**.
 
-        * **data[i].steamIDUser** (`steamID`) -- User who this entry belongs to. You can use :func:`friends.getFriendPersonaName` and :func:`friends.getSmallFriendAvatar` **(missing)** to get more info.
+        * **data[i].steamIDUser** (`uint64`) -- User who this entry belongs to. You can use :func:`friends.getFriendPersonaName` and :func:`friends.getSmallFriendAvatar` **(missing)** to get more info.
 
         * **data[i].globalRank** (`number`) -- The global rank of this entry ranging from [1..N], where N is the number of users with an entry in the leaderboard.
 
@@ -328,7 +328,7 @@ Function Reference
 
         * **data[i].details** (`string`) -- Details of the entry. String is used as a byte array, so may contain a ``'\0'`` in the middle.
 
-        * **data[i].UGC** (`ugcHandle`) -- 	Handle for the UGC attached to the entry. A special value if there is none. **(useless for now, as there are no UGC functions implemented)**
+        * **data[i].UGC** (`uint64`) -- 	Handle for the UGC attached to the entry. A special value if there is none.
 
     * **err** (`boolean`): **true** if there was any IO error with the request.
 

--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -1,0 +1,24 @@
+###########
+ISteamUtils
+###########
+
+List of Functions
+-----------------
+
+* :func:`utils.getAppID`
+
+
+Function Reference
+------------------
+
+.. function:: utils.getAppID ()
+
+    :returns: (`number`) The AppID.
+    :SteamWorks: `GetAppID <https://partner.steamgames.com/doc/api/ISteamUtils#GetAppID>`_
+
+	Gets the App ID of the current process.
+
+**Example**::
+
+    print("My app id is " .. Steam.utils.getAppID())
+

--- a/src/UGC.cpp
+++ b/src/UGC.cpp
@@ -1,0 +1,67 @@
+#include "UGC.hpp"
+
+// ========================
+// ======= SteamUGC =======
+// ========================
+
+using luasteam::CallResultListener;
+
+namespace {
+
+const char *workshop_file_types[] = {"Community", "Microtransaction", "Collection", "Art", "Video", "Screenshot", "WebGuide", "IntegratedGuide", "Merch", "ControllerBinding", "SteamVideo", "GameManagedItem", nullptr};
+
+// This is used since not all file types are valid
+const EWorkshopFileType file_type_to_enum[] = {k_EWorkshopFileTypeCommunity, k_EWorkshopFileTypeMicrotransaction, k_EWorkshopFileTypeCollection, k_EWorkshopFileTypeArt, k_EWorkshopFileTypeVideo, k_EWorkshopFileTypeScreenshot, k_EWorkshopFileTypeWebGuide, k_EWorkshopFileTypeIntegratedGuide, k_EWorkshopFileTypeMerch, k_EWorkshopFileTypeControllerBinding, k_EWorkshopFileTypeSteamVideo, k_EWorkshopFileTypeGameManagedItem};
+
+} // namespace
+
+namespace luasteam {
+
+template <> void CallResultListener<CreateItemResult_t>::Result(CreateItemResult_t *data, bool io_fail) {
+    lua_State *L = luasteam::global_lua_state;
+    // getting stored callback function
+    lua_rawgeti(L, LUA_REGISTRYINDEX, callback_ref);
+    luaL_unref(L, LUA_REGISTRYINDEX, callback_ref);
+    // calling function
+    if (io_fail) {
+        lua_pushnil(L);
+    } else {
+        lua_createtable(L, 0, 3);
+        lua_pushnumber(L, data->m_eResult);
+        lua_setfield(L, -2, "result");
+        luasteam::pushuint64(L, data->m_nPublishedFileId);
+        lua_setfield(L, -2, "publishedFileId");
+        lua_pushboolean(L, data->m_bUserNeedsToAcceptWorkshopLegalAgreement);
+        lua_setfield(L, -2, "userNeedsToAcceptWorkshopLegalAgreement");
+    }
+    lua_pushboolean(L, io_fail);
+    lua_call(L, 2, 0);
+    delete this; // DELET THIS
+}
+
+} // namespace luasteam
+
+EXTERN int luasteam_createItem(lua_State *L) {
+    int consumerAppID = luaL_checkint(L, 1);
+    EWorkshopFileType fileType = file_type_to_enum[luaL_checkoption(L, 2, nullptr, workshop_file_types)];
+    luaL_checktype(L, 3, LUA_TFUNCTION);
+    auto *listener = new CallResultListener<CreateItemResult_t>();
+    listener->callback_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+    SteamAPICall_t call = SteamUGC()->CreateItem(consumerAppID, fileType);
+    listener->call_result.Set(call, listener, &CallResultListener<CreateItemResult_t>::Result);
+    return 0;
+}
+
+namespace luasteam {
+
+void add_UGC(lua_State *L) {
+    lua_createtable(L, 0, 1);
+    add_func(L, "createItem", luasteam_createItem);
+    lua_setfield(L, -2, "UGC");
+}
+
+void init_UGC(lua_State *L) {}
+
+void shutdown_UGC(lua_State *L) {}
+
+} // namespace luasteam

--- a/src/UGC.cpp
+++ b/src/UGC.cpp
@@ -9,6 +9,10 @@ using luasteam::CallResultListener;
 
 namespace {
 
+const char *update_status[] = {
+    "Invalid", "PreparingConfig", "PreparingContent", "UploadingContent", "UploadingPreviewFile", "CommittingChanges",
+};
+
 const char *workshop_file_types[] = {
     "Community", "Microtransaction", "Collection", "Art", "Video", "Screenshot", "WebGuide", "IntegratedGuide", "Merch", "ControllerBinding", "SteamVideo", "GameManagedItem", nullptr,
 };
@@ -223,8 +227,19 @@ EXTERN int luasteam_getItemInstallInfo(lua_State *L) {
         return 1;
 }
 
+// EItemUpdateStatus GetItemUpdateProgress( UGCUpdateHandle_t handle, uint64 *punBytesProcessed, uint64*punBytesTotal );
+EXTERN int luasteam_getItemUpdateProgress(lua_State *L) {
+    uint64 handle = luasteam::checkuint64(L, 1);
+    uint64 processed, total;
+    EItemUpdateStatus st = SteamUGC()->GetItemUpdateProgress(handle, &processed, &total);
+    lua_pushstring(L, update_status[st]);
+    lua_pushnumber(L, processed);
+    lua_pushnumber(L, total);
+    return 3;
+}
+
 // the table should be on index
-std::vector<PublishedFileId_t> getFileIdList(lua_State *L, int index) {
+static std::vector<PublishedFileId_t> getFileIdList(lua_State *L, int index) {
     luaL_checktype(L, index, LUA_TTABLE);
     const int size = lua_objlen(L, index);
     if (size < 1 || size > 100) {
@@ -283,7 +298,7 @@ EXTERN int luasteam_stopPlaytimeTrackingForAllItems(lua_State *L) {
 namespace luasteam {
 
 void add_UGC(lua_State *L) {
-    lua_createtable(L, 0, 14);
+    lua_createtable(L, 0, 15);
     add_func(L, "createItem", luasteam_createItem);
     add_func(L, "startItemUpdate", luasteam_startItemUpdate);
     add_func(L, "setItemContent", luasteam_setItemContent);
@@ -295,6 +310,7 @@ void add_UGC(lua_State *L) {
     add_func(L, "getSubscribedItems", luasteam_getSubscribedItems);
     add_func(L, "getItemState", luasteam_getItemState);
     add_func(L, "getItemInstallInfo", luasteam_getItemInstallInfo);
+    add_func(L, "getItemUpdateProgress", luasteam_getItemUpdateProgress);
     add_func(L, "startPlaytimeTracking", luasteam_startPlaytimeTracking);
     add_func(L, "stopPlaytimeTracking", luasteam_stopPlaytimeTracking);
     add_func(L, "stopPlaytimeTrackingForAllItems", luasteam_stopPlaytimeTrackingForAllItems);

--- a/src/UGC.cpp
+++ b/src/UGC.cpp
@@ -8,10 +8,13 @@ using luasteam::CallResultListener;
 
 namespace {
 
-const char *workshop_file_types[] = {"Community", "Microtransaction", "Collection", "Art", "Video", "Screenshot", "WebGuide", "IntegratedGuide", "Merch", "ControllerBinding", "SteamVideo", "GameManagedItem", nullptr};
+const char *workshop_file_types[] = {
+    "Community", "Microtransaction", "Collection", "Art", "Video", "Screenshot", "WebGuide", "IntegratedGuide", "Merch", "ControllerBinding", "SteamVideo", "GameManagedItem", nullptr,
+};
 
-// This is used since not all file types are valid
-const EWorkshopFileType file_type_to_enum[] = {k_EWorkshopFileTypeCommunity, k_EWorkshopFileTypeMicrotransaction, k_EWorkshopFileTypeCollection, k_EWorkshopFileTypeArt, k_EWorkshopFileTypeVideo, k_EWorkshopFileTypeScreenshot, k_EWorkshopFileTypeWebGuide, k_EWorkshopFileTypeIntegratedGuide, k_EWorkshopFileTypeMerch, k_EWorkshopFileTypeControllerBinding, k_EWorkshopFileTypeSteamVideo, k_EWorkshopFileTypeGameManagedItem};
+const EWorkshopFileType file_type_to_enum[] = {
+    k_EWorkshopFileTypeCommunity, k_EWorkshopFileTypeMicrotransaction, k_EWorkshopFileTypeCollection, k_EWorkshopFileTypeArt, k_EWorkshopFileTypeVideo, k_EWorkshopFileTypeScreenshot, k_EWorkshopFileTypeWebGuide, k_EWorkshopFileTypeIntegratedGuide, k_EWorkshopFileTypeMerch, k_EWorkshopFileTypeControllerBinding, k_EWorkshopFileTypeSteamVideo, k_EWorkshopFileTypeGameManagedItem,
+};
 
 } // namespace
 
@@ -39,8 +42,29 @@ template <> void CallResultListener<CreateItemResult_t>::Result(CreateItemResult
     delete this; // DELET THIS
 }
 
+template <> void CallResultListener<SubmitItemUpdateResult_t>::Result(SubmitItemUpdateResult_t *data, bool io_fail) {
+    lua_State *L = luasteam::global_lua_state;
+    // getting stored callback function
+    lua_rawgeti(L, LUA_REGISTRYINDEX, callback_ref);
+    luaL_unref(L, LUA_REGISTRYINDEX, callback_ref);
+    // calling function
+    if (io_fail)
+        lua_pushnil(L);
+    else {
+        lua_createtable(L, 0, 2);
+        lua_pushnumber(L, data->m_eResult);
+        lua_setfield(L, -2, "result");
+        lua_pushboolean(L, data->m_bUserNeedsToAcceptWorkshopLegalAgreement);
+        lua_setfield(L, -2, "userNeedsToAcceptWorkshopLegalAgreement");
+    }
+    lua_pushboolean(L, io_fail);
+    lua_call(L, 2, 0);
+    delete this;
+}
+
 } // namespace luasteam
 
+// SteamAPICall_t CreateItem( AppId_t nConsumerAppId, EWorkshopFileType eFileType );
 EXTERN int luasteam_createItem(lua_State *L) {
     int consumerAppID = luaL_checkint(L, 1);
     EWorkshopFileType fileType = file_type_to_enum[luaL_checkoption(L, 2, nullptr, workshop_file_types)];
@@ -52,11 +76,69 @@ EXTERN int luasteam_createItem(lua_State *L) {
     return 0;
 }
 
+// UGCUpdateHandle_t StartItemUpdate( AppId_t nConsumerAppId, PublishedFileId_t nPublishedFileID );
+EXTERN int luasteam_startItemUpdate(lua_State *L) {
+    int consumerAppID = luaL_checkint(L, 1);
+    uint64 publishedFileId = luasteam::checkuint64(L, 2);
+    luasteam::pushuint64(L, SteamUGC()->StartItemUpdate(consumerAppID, publishedFileId));
+    return 1;
+}
+
+// bool SetItemContent( UGCUpdateHandle_t handle, const char *pszContentFolder );
+EXTERN int luasteam_setItemContent(lua_State *L) {
+    uint64 handle = luasteam::checkuint64(L, 1);
+    const char *contentFolder = luaL_checkstring(L, 2);
+    lua_pushboolean(L, SteamUGC()->SetItemContent(handle, contentFolder));
+    return 1;
+}
+
+// bool SetItemDescription( UGCUpdateHandle_t handle, const char *pchDescription );
+EXTERN int luasteam_setItemDescription(lua_State *L) {
+    uint64 handle = luasteam::checkuint64(L, 1);
+    const char *description = luaL_checkstring(L, 2);
+    lua_pushboolean(L, SteamUGC()->SetItemDescription(handle, description));
+    return 1;
+}
+
+// bool SetItemPreview( UGCUpdateHandle_t handle, const char *pszPreviewFile );
+EXTERN int luasteam_setItemPreview(lua_State *L) {
+    uint64 handle = luasteam::checkuint64(L, 1);
+    const char *previewFile = luaL_checkstring(L, 2);
+    lua_pushboolean(L, SteamUGC()->SetItemPreview(handle, previewFile));
+    return 1;
+}
+
+// bool SetItemTitle( UGCUpdateHandle_t handle, const char *pchTitle );
+EXTERN int luasteam_setItemTitle(lua_State *L) {
+    uint64 handle = luasteam::checkuint64(L, 1);
+    const char *title = luaL_checkstring(L, 2);
+    lua_pushboolean(L, SteamUGC()->SetItemTitle(handle, title));
+    return 1;
+}
+
+// SteamAPICall_t SubmitItemUpdate( UGCUpdateHandle_t handle, const char *pchChangeNote );
+EXTERN int luasteam_submitItemUpdate(lua_State *L) {
+    uint64 handle = luasteam::checkuint64(L, 1);
+    const char *changeNote = luaL_optstring(L, 2, nullptr);
+    luaL_checktype(L, 3, LUA_TFUNCTION);
+    auto *listener = new CallResultListener<SubmitItemUpdateResult_t>();
+    listener->callback_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+    SteamAPICall_t call = SteamUGC()->SubmitItemUpdate(handle, changeNote);
+    listener->call_result.Set(call, listener, &CallResultListener<SubmitItemUpdateResult_t>::Result);
+    return 0;
+}
+
 namespace luasteam {
 
 void add_UGC(lua_State *L) {
-    lua_createtable(L, 0, 1);
+    lua_createtable(L, 0, 7);
     add_func(L, "createItem", luasteam_createItem);
+    add_func(L, "startItemUpdate", luasteam_startItemUpdate);
+    add_func(L, "setItemContent", luasteam_setItemContent);
+    add_func(L, "setItemDescription", luasteam_setItemDescription);
+    add_func(L, "setItemPreview", luasteam_setItemPreview);
+    add_func(L, "setItemTitle", luasteam_setItemTitle);
+    add_func(L, "submitItemUpdate", luasteam_submitItemUpdate);
     lua_setfield(L, -2, "UGC");
 }
 

--- a/src/UGC.cpp
+++ b/src/UGC.cpp
@@ -128,10 +128,30 @@ EXTERN int luasteam_submitItemUpdate(lua_State *L) {
     return 0;
 }
 
+// uint32 GetNumSubscribedItems();
+EXTERN int luasteam_getNumSubscribedItems(lua_State *L) {
+    lua_pushnumber(L, SteamUGC()->GetNumSubscribedItems());
+    return 1;
+}
+
+// uint32 GetSubscribedItems( PublishedFileId_t*pvecPublishedFileID, uint32 cMaxEntries );
+EXTERN int luasteam_getSubscribedItems(lua_State *L) {
+    int sz = SteamUGC()->GetNumSubscribedItems();
+    PublishedFileId_t *vec = new PublishedFileId_t[sz];
+    sz = SteamUGC()->GetSubscribedItems(vec, sz);
+    lua_createtable(L, sz, 0);
+    for(int i = 0; i < sz; i++) {
+        luasteam::pushuint64(L, vec[i]);
+        lua_rawseti(L, -2, i + 1);
+    }
+    delete vec;
+    return 1;
+}
+
 namespace luasteam {
 
 void add_UGC(lua_State *L) {
-    lua_createtable(L, 0, 7);
+    lua_createtable(L, 0, 9);
     add_func(L, "createItem", luasteam_createItem);
     add_func(L, "startItemUpdate", luasteam_startItemUpdate);
     add_func(L, "setItemContent", luasteam_setItemContent);
@@ -139,6 +159,8 @@ void add_UGC(lua_State *L) {
     add_func(L, "setItemPreview", luasteam_setItemPreview);
     add_func(L, "setItemTitle", luasteam_setItemTitle);
     add_func(L, "submitItemUpdate", luasteam_submitItemUpdate);
+    add_func(L, "getNumSubscribedItems", luasteam_getNumSubscribedItems);
+    add_func(L, "getSubscribedItems", luasteam_getSubscribedItems);
     lua_setfield(L, -2, "UGC");
 }
 

--- a/src/UGC.cpp
+++ b/src/UGC.cpp
@@ -227,7 +227,9 @@ EXTERN int luasteam_getItemInstallInfo(lua_State *L) {
 std::vector<PublishedFileId_t> getFileIdList(lua_State *L, int index) {
     luaL_checktype(L, index, LUA_TTABLE);
     const int size = lua_objlen(L, index);
-    if (size < 1 || size > 100) return {};
+    if (size < 1 || size > 100) {
+        return {};
+    }
     std::vector<PublishedFileId_t> vec(size);
     for (int i = 0; i < size; i++) {
         lua_rawgeti(L, index, i + 1);
@@ -241,7 +243,9 @@ std::vector<PublishedFileId_t> getFileIdList(lua_State *L, int index) {
 EXTERN int luasteam_startPlaytimeTracking(lua_State *L) {
     luaL_checktype(L, 2, LUA_TFUNCTION);
     std::vector<PublishedFileId_t> vec(getFileIdList(L, 1));
-    if (vec.empty()) return 0;
+    if (vec.empty()) {
+        return 0;
+    }
     SteamAPICall_t call = SteamUGC()->StartPlaytimeTracking(&vec[0], vec.size());
     auto *listener = new CallResultListener<StartPlaytimeTrackingResult_t>();
     lua_settop(L, 2);
@@ -254,7 +258,9 @@ EXTERN int luasteam_startPlaytimeTracking(lua_State *L) {
 EXTERN int luasteam_stopPlaytimeTracking(lua_State *L) {
     luaL_checktype(L, 2, LUA_TFUNCTION);
     auto vec = getFileIdList(L, 1);
-    if (vec.empty()) return 0;
+    if (vec.empty()) {
+        return 0;
+    }
     SteamAPICall_t call = SteamUGC()->StopPlaytimeTracking(&vec[0], vec.size());
     auto *listener = new CallResultListener<StopPlaytimeTrackingResult_t>();
     lua_settop(L, 2);

--- a/src/UGC.hpp
+++ b/src/UGC.hpp
@@ -1,0 +1,16 @@
+#ifndef LUASTEAM_UGC
+#define LUASTEAM_UGC
+
+#include "common.hpp"
+
+namespace luasteam {
+
+// Adds functions from ISteamUGC
+void add_UGC(lua_State *L);
+
+void init_UGC(lua_State *L);
+void shutdown_UGC(lua_State *L);
+
+} // namespace luasteam
+
+#endif // LUASTEAM_UGC

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -1,10 +1,13 @@
 #include "common.hpp"
+#include <string>
 
 namespace {
 int uint64Metatable_ref = LUA_NOREF;
 
 void my_assert(lua_State *L, int cond, const char *fmt, va_list list) {
-    if (cond) return;
+    if (cond) {
+        return;
+    }
     lua_pushvfstring(L, fmt, list);
     lua_error(L);
 }
@@ -12,6 +15,12 @@ void my_assert(lua_State *L, int cond, const char *fmt, va_list list) {
 } // namespace
 
 EXTERN int luasteam_equint64(lua_State *L) { return luasteam::checkuint64(L, 1) == luasteam::checkuint64(L, 2); }
+
+EXTERN int luasteam_uint64ToString(lua_State *L) {
+    uint64 x = luasteam::checkuint64(L, 1);
+    lua_pushstring(L, std::to_string(x).data());
+    return 1;
+}
 
 namespace luasteam {
 
@@ -53,8 +62,9 @@ void add_func(lua_State *L, const char *name, lua_CFunction func) {
 
 void init_common(lua_State *L) {
     global_lua_state = L;
-    lua_createtable(L, 0, 1);
+    lua_createtable(L, 0, 2);
     add_func(L, "__eq", luasteam_equint64);
+    add_func(L, "__tostring", luasteam_uint64ToString);
     uint64Metatable_ref = luaL_ref(L, LUA_REGISTRYINDEX);
 }
 

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -4,6 +4,8 @@ namespace {
 int uint64Metatable_ref = LUA_NOREF;
 } // namespace
 
+EXTERN int luasteam_equint64(lua_State *L) { return luasteam::checkuint64(L, 1) == luasteam::checkuint64(L, 2); }
+
 namespace luasteam {
 
 lua_State *global_lua_state = nullptr;
@@ -32,7 +34,8 @@ void add_func(lua_State *L, const char *name, lua_CFunction func) {
 
 void init_common(lua_State *L) {
     global_lua_state = L;
-    lua_createtable(L, 0, 0);
+    lua_createtable(L, 0, 1);
+    add_func(L, "__eq", luasteam_equint64);
     uint64Metatable_ref = luaL_ref(L, LUA_REGISTRYINDEX);
 }
 

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -2,6 +2,13 @@
 
 namespace {
 int uint64Metatable_ref = LUA_NOREF;
+
+void my_assert(lua_State *L, int cond, const char *fmt, va_list list) {
+    if (cond) return;
+    lua_pushvfstring(L, fmt, list);
+    lua_error(L);
+}
+
 } // namespace
 
 EXTERN int luasteam_equint64(lua_State *L) { return luasteam::checkuint64(L, 1) == luasteam::checkuint64(L, 2); }
@@ -24,6 +31,18 @@ uint64 checkuint64(lua_State *L, int nParam) {
     luaL_argcheck(L, lua_rawequal(L, -2, -1), nParam, "must be uint64");
     lua_pop(L, 2);
     uint64 *ptr = reinterpret_cast<uint64 *>(lua_touserdata(L, nParam));
+    return *ptr;
+}
+
+uint64 assertuint64(lua_State *L, int index, const char *fmt, ...) {
+    va_list list;
+    va_start(list, fmt);
+    my_assert(L, lua_isuserdata(L, index), fmt, list);
+    lua_rawgeti(L, LUA_REGISTRYINDEX, uint64Metatable_ref);
+    lua_getmetatable(L, index);
+    my_assert(L, lua_rawequal(L, -2, -1), fmt, list);
+    lua_pop(L, 2);
+    uint64 *ptr = reinterpret_cast<uint64 *>(lua_touserdata(L, index));
     return *ptr;
 }
 

--- a/src/common.hpp
+++ b/src/common.hpp
@@ -25,6 +25,14 @@ uint64 checkuint64(lua_State *L, int nParam);
 // Adds a C function to the table on top of the stack, with given name
 void add_func(lua_State *L, const char *name, lua_CFunction func);
 
+
+template <typename T> class CallResultListener {
+  public:
+    int callback_ref = LUA_NOREF;
+    void Result(T *data, bool io_fail);
+    CCallResult<CallResultListener, T> call_result;
+};
+
 void init_common(lua_State *L);
 void shutdown_common(lua_State *L);
 

--- a/src/common.hpp
+++ b/src/common.hpp
@@ -26,7 +26,6 @@ uint64 assertuint64(lua_State *L, int index, const char *fmt, ...);
 // Adds a C function to the table on top of the stack, with given name
 void add_func(lua_State *L, const char *name, lua_CFunction func);
 
-
 template <typename T> class CallResultListener {
   public:
     int callback_ref = LUA_NOREF;

--- a/src/common.hpp
+++ b/src/common.hpp
@@ -21,6 +21,7 @@ extern lua_State *global_lua_state;
 // using userdata since Lua's number can't safely hold 64-bit integers
 void pushuint64(lua_State *L, uint64 v);
 uint64 checkuint64(lua_State *L, int nParam);
+uint64 assertuint64(lua_State *L, int index, const char *fmt, ...);
 
 // Adds a C function to the table on top of the stack, with given name
 void add_func(lua_State *L, const char *name, lua_CFunction func);

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -1,6 +1,7 @@
 #include "core.hpp"
 #include "friends.hpp"
 #include "user_stats.hpp"
+#include "utils.hpp"
 
 // ========================
 // ======= SteamAPI =======
@@ -13,6 +14,7 @@ EXTERN int luasteam_init(lua_State *L) {
         luasteam::init_common(L);
         luasteam::init_friends(L);
         luasteam::init_user_stats(L);
+        luasteam::init_utils(L);
     } else {
         fprintf(stderr, "Couldn't connect to steam...\nDo you have Steam turned on?\nIf not running from steam, do you have a correct steam_appid.txt file?\n");
     }
@@ -24,6 +26,7 @@ EXTERN int luasteam_init(lua_State *L) {
 EXTERN int luasteam_shutdown(lua_State *L) {
     SteamAPI_Shutdown();
     // Cleaning up
+    luasteam::shutdown_utils(L);
     luasteam::shutdown_user_stats(L);
     luasteam::shutdown_friends(L);
     luasteam::shutdown_common(L);

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -1,8 +1,9 @@
 #include "core.hpp"
+#include "UGC.hpp"
+#include "extra.hpp"
 #include "friends.hpp"
 #include "user_stats.hpp"
 #include "utils.hpp"
-#include "UGC.hpp"
 
 // ========================
 // ======= SteamAPI =======
@@ -17,6 +18,7 @@ EXTERN int luasteam_init(lua_State *L) {
         luasteam::init_user_stats(L);
         luasteam::init_utils(L);
         luasteam::init_UGC(L);
+        luasteam::init_extra(L);
     } else {
         fprintf(stderr, "Couldn't connect to steam...\nDo you have Steam turned on?\nIf not running from steam, do you have a correct steam_appid.txt file?\n");
     }
@@ -28,6 +30,7 @@ EXTERN int luasteam_init(lua_State *L) {
 EXTERN int luasteam_shutdown(lua_State *L) {
     SteamAPI_Shutdown();
     // Cleaning up
+    luasteam::shutdown_extra(L);
     luasteam::shutdown_UGC(L);
     luasteam::shutdown_utils(L);
     luasteam::shutdown_user_stats(L);

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -2,6 +2,7 @@
 #include "friends.hpp"
 #include "user_stats.hpp"
 #include "utils.hpp"
+#include "UGC.hpp"
 
 // ========================
 // ======= SteamAPI =======
@@ -15,6 +16,7 @@ EXTERN int luasteam_init(lua_State *L) {
         luasteam::init_friends(L);
         luasteam::init_user_stats(L);
         luasteam::init_utils(L);
+        luasteam::init_UGC(L);
     } else {
         fprintf(stderr, "Couldn't connect to steam...\nDo you have Steam turned on?\nIf not running from steam, do you have a correct steam_appid.txt file?\n");
     }
@@ -26,6 +28,7 @@ EXTERN int luasteam_init(lua_State *L) {
 EXTERN int luasteam_shutdown(lua_State *L) {
     SteamAPI_Shutdown();
     // Cleaning up
+    luasteam::shutdown_UGC(L);
     luasteam::shutdown_utils(L);
     luasteam::shutdown_user_stats(L);
     luasteam::shutdown_friends(L);

--- a/src/extra.cpp
+++ b/src/extra.cpp
@@ -1,0 +1,25 @@
+#include "extra.hpp"
+#include <cstdlib>
+
+// Returns 0 if string is invalid
+EXTERN int luasteam_uint64FromString(lua_State *L) {
+    const char *str = luaL_checkstring(L, 1);
+    // strto* are safer than ato*
+    uint64 x = strtoull(str, nullptr, 10);
+    luasteam::pushuint64(L, x);
+    return 1;
+}
+
+namespace luasteam {
+
+void add_extra(lua_State *L) {
+    lua_createtable(L, 0, 1);
+    add_func(L, "uint64FromString", luasteam_uint64FromString);
+    lua_setfield(L, -2, "extra");
+}
+
+void init_extra(lua_State *L) {}
+
+void shutdown_extra(lua_State *L) {}
+
+} // namespace luasteam

--- a/src/extra.cpp
+++ b/src/extra.cpp
@@ -2,7 +2,7 @@
 #include <cstdlib>
 
 // Returns 0 if string is invalid
-EXTERN int luasteam_uint64FromString(lua_State *L) {
+EXTERN int luasteam_parseUint64(lua_State *L) {
     const char *str = luaL_checkstring(L, 1);
     // strto* are safer than ato*
     uint64 x = strtoull(str, nullptr, 10);
@@ -14,7 +14,7 @@ namespace luasteam {
 
 void add_extra(lua_State *L) {
     lua_createtable(L, 0, 1);
-    add_func(L, "uint64FromString", luasteam_uint64FromString);
+    add_func(L, "parseUint64", luasteam_parseUint64);
     lua_setfield(L, -2, "extra");
 }
 

--- a/src/extra.hpp
+++ b/src/extra.hpp
@@ -1,0 +1,16 @@
+#ifndef LUASTEAM_EXTRA
+#define LUASTEAM_EXTRA
+
+#include "common.hpp"
+
+namespace luasteam {
+
+// Adds extra functions
+void add_extra(lua_State *L);
+
+void init_extra(lua_State *L);
+void shutdown_extra(lua_State *L);
+
+} // namespace luasteam
+
+#endif // LUASTEAM_EXTRA

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,19 +1,21 @@
+#include "UGC.hpp"
 #include "common.hpp"
 #include "core.hpp"
+#include "extra.hpp"
 #include "friends.hpp"
 #include "user.hpp"
 #include "user_stats.hpp"
 #include "utils.hpp"
-#include "UGC.hpp"
 
 // Creates and returns a table with all functions
 EXTERN int luaopen_luasteam(lua_State *L) {
-    lua_createtable(L, 0, 8);
+    lua_createtable(L, 0, 9);
     luasteam::add_core(L);
     luasteam::add_friends(L);
     luasteam::add_user(L);
     luasteam::add_user_stats(L);
     luasteam::add_utils(L);
     luasteam::add_UGC(L);
+    luasteam::add_extra(L);
     return 1;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,13 +3,15 @@
 #include "friends.hpp"
 #include "user.hpp"
 #include "user_stats.hpp"
+#include "utils.hpp"
 
 // Creates and returns a table with all functions
 EXTERN int luaopen_luasteam(lua_State *L) {
-    lua_createtable(L, 0, 6);
+    lua_createtable(L, 0, 7);
     luasteam::add_core(L);
     luasteam::add_friends(L);
     luasteam::add_user(L);
     luasteam::add_user_stats(L);
+    luasteam::add_utils(L);
     return 1;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,14 +4,16 @@
 #include "user.hpp"
 #include "user_stats.hpp"
 #include "utils.hpp"
+#include "UGC.hpp"
 
 // Creates and returns a table with all functions
 EXTERN int luaopen_luasteam(lua_State *L) {
-    lua_createtable(L, 0, 7);
+    lua_createtable(L, 0, 8);
     luasteam::add_core(L);
     luasteam::add_friends(L);
     luasteam::add_user(L);
     luasteam::add_user_stats(L);
     luasteam::add_utils(L);
+    luasteam::add_UGC(L);
     return 1;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,13 +1,15 @@
 #include "common.hpp"
 #include "core.hpp"
 #include "friends.hpp"
+#include "user.hpp"
 #include "user_stats.hpp"
 
 // Creates and returns a table with all functions
 EXTERN int luaopen_luasteam(lua_State *L) {
-    lua_createtable(L, 0, 5);
+    lua_createtable(L, 0, 6);
     luasteam::add_core(L);
-    luasteam::add_user_stats(L);
     luasteam::add_friends(L);
+    luasteam::add_user(L);
+    luasteam::add_user_stats(L);
     return 1;
 }

--- a/src/user.cpp
+++ b/src/user.cpp
@@ -1,0 +1,28 @@
+#include "user.hpp"
+
+// int GetPlayerSteamLevel();
+EXTERN int luasteam_getPlayerSteamLevel(lua_State *L) {
+    lua_pushnumber(L, SteamUser()->GetPlayerSteamLevel());
+    return 1;
+}
+
+// CSteamID GetSteamID();
+EXTERN int luasteam_getSteamID(lua_State *L) {
+    luasteam::pushuint64(L, SteamUser()->GetSteamID().ConvertToUint64());
+    return 1;
+}
+
+namespace luasteam {
+
+void add_user(lua_State *L) {
+    lua_createtable(L, 0, 2);
+    add_func(L, "getPlayerSteamLevel", luasteam_getPlayerSteamLevel);
+    add_func(L, "getSteamID", luasteam_getSteamID);
+    lua_setfield(L, -2, "user");
+}
+
+void init_user(lua_State *L) {}
+
+void shutdown_user(lua_State *L) {}
+
+} // namespace luasteam

--- a/src/user.hpp
+++ b/src/user.hpp
@@ -1,0 +1,16 @@
+#ifndef LUASTEAM_USER
+#define LUASTEAM_USER
+
+#include "common.hpp"
+
+namespace luasteam {
+
+// Adds functions from ISteamUser
+void add_user(lua_State *L);
+
+void init_user(lua_State *L);
+void shutdown_user(lua_State *L);
+
+} // namespace luasteam
+
+#endif // LUASTEAM_USER

--- a/src/user_stats.cpp
+++ b/src/user_stats.cpp
@@ -4,6 +4,8 @@
 // ======= SteamUserStats =======
 // ==============================
 
+using luasteam::CallResultListener;
+
 namespace {
 
 class CallbackListener;
@@ -97,12 +99,9 @@ void CallbackListener::OnUserAchievementStored(UserAchievementStored_t *data) {
     }
 }
 
-template <typename T> class CallResultListener {
-  public:
-    int callback_ref = LUA_NOREF;
-    void Result(T *data, bool io_fail);
-    CCallResult<CallResultListener, T> call_result;
-};
+} // namespace
+
+namespace luasteam {
 
 template <> void CallResultListener<LeaderboardFindResult_t>::Result(LeaderboardFindResult_t *data, bool io_fail) {
     lua_State *L = luasteam::global_lua_state;
@@ -191,7 +190,7 @@ template <> void CallResultListener<LeaderboardScoresDownloaded_t>::Result(Leade
     delete this;
 }
 
-} // namespace
+} // namespace luasteam
 
 // bool GetAchievement(const char *pchName, bool *pbAchieved );
 EXTERN int luasteam_getAchievement(lua_State *L) {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -4,7 +4,6 @@
 // ======= SteamUtils =======
 // ==========================
 
-
 // uint32 GetAppID();
 EXTERN int luasteam_getAppID(lua_State *L) {
     lua_pushnumber(L, SteamUtils()->GetAppID());

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,0 +1,26 @@
+#include "utils.hpp"
+
+// ==========================
+// ======= SteamUtils =======
+// ==========================
+
+
+// uint32 GetAppID();
+EXTERN int luasteam_getAppID(lua_State *L) {
+    lua_pushnumber(L, SteamUtils()->GetAppID());
+    return 1;
+}
+
+namespace luasteam {
+
+void add_utils(lua_State *L) {
+    lua_createtable(L, 0, 1);
+    add_func(L, "getAppID", luasteam_getAppID);
+    lua_setfield(L, -2, "utils");
+}
+
+void init_utils(lua_State *L) {}
+
+void shutdown_utils(lua_State *L) {}
+
+} // namespace luasteam

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -1,0 +1,16 @@
+#ifndef LUASTEAM_UTILS
+#define LUASTEAM_UTILS
+
+#include "common.hpp"
+
+namespace luasteam {
+
+// Adds functions from ISteamUtils
+void add_utils(lua_State *L);
+
+void init_utils(lua_State *L);
+void shutdown_utils(lua_State *L);
+
+} // namespace luasteam
+
+#endif // LUASTEAM_UTILS


### PR DESCRIPTION
**Depends on #6**

Added many new functions to luasteam. Mostly functions I'm using at MarvInc, so they relate to Workshop stuff. All of them have documentation.

Functions added:
- ISteamUGC
  - createItem
  - startItemUpdate
  - setItemContent
  - setItemDescription
  - setItemPreview
  - setItemTitle
  - submitItemUpdateResult
  - getNumSubscribedItems
  - getSubscribedItems
  - getItemState
  - getItemInstallInfo
  - getItemUpdateProgress
  - startPlaytimeTracking
  - stopPlaytimeTracking
  - stopPlaytimeTrackingForAllItems
- ISteamUser
  - getPlayerSteamLevel
  - getSteamID
- ISteamUtils
  - getAppID
- Extra (not originally on the SDK)
  - parseUint64

Other changes:
- uint64's (leaderboard handles, steam ids, etc.) can now be compared with equality and converted to and from strings.
- Improved uint64 documentation