### PR TITLE
Add current language from ISteamApps

### DIFF
--- a/docs/apps.rst
+++ b/docs/apps.rst
@@ -1,0 +1,27 @@
+###########
+ISteamApps
+###########
+
+List of Functions
+-----------------
+
+* :func:`apps.getCurrentGameLanguage`
+
+
+Function Reference
+------------------
+
+.. function:: apps.getCurrentGameLanguage()
+
+    :returns: (`string`) The language that the user has set.
+    :SteamWorks: `GetCurrentGameLanguage <https://partner.steamgames.com/doc/api/ISteamApps#GetCurrentGameLanguage>`_
+
+	Gets the current language that the user has set. This falls back to the Steam UI language if the user hasn't explicitly picked a language for the title.
+
+  For the full list of languages see `Supported Languages <https://partner.steamgames.com/doc/store/localization#supported_languages>`_
+
+
+**Example**::
+
+    print("The games current language is " .. Steam.apps.getCurrentGameLanguage())
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,6 +22,7 @@ While using this documentation, you may also like to check the `SteamWorks API R
     ISteamUser <user>
     ISteamUserStats <user_stats>
     ISteamUtils <utils>
+    ISteamApps <apps>
     ISteamUGC <UGC>
     Extra <extra>
 

--- a/src/apps.cpp
+++ b/src/apps.cpp
@@ -1,0 +1,25 @@
+#include "apps.hpp"
+
+// ============================
+// ======== SteamApps =========
+// ============================
+
+// const char * GetCurrentGameLanguage();
+EXTERN int luasteam_getCurrentGameLanguage(lua_State *L) {
+  lua_pushstring(L, SteamApps()->GetCurrentGameLanguage());
+  return 1;
+}
+
+namespace luasteam {
+
+void add_apps(lua_State *L) {
+    lua_createtable(L, 0, 1);
+    add_func(L, "getCurrentGameLanguage", luasteam_getCurrentGameLanguage);
+    lua_setfield(L, -2, "apps");
+}
+
+void init_apps(lua_State *L) {}
+
+void shutdown_apps(lua_State *L) {}
+
+} // namespace luasteam

--- a/src/apps.hpp
+++ b/src/apps.hpp
@@ -1,0 +1,16 @@
+#ifndef LUASTEAM_APPS
+#define LUASTEAM_APPS
+
+#include "common.hpp"
+
+namespace luasteam {
+
+// Adds functions from ISteamApps
+void add_apps(lua_State *L);
+
+void init_apps(lua_State *L);
+void shutdown_apps(lua_State *L);
+
+} // namespace luasteam
+
+#endif // LUASTEAM_APPS

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -19,6 +19,7 @@ EXTERN int luasteam_init(lua_State *L) {
         luasteam::init_utils(L);
         luasteam::init_UGC(L);
         luasteam::init_extra(L);
+        luasteam::init_apps(L);
     } else {
         fprintf(stderr, "Couldn't connect to steam...\nDo you have Steam turned on?\nIf not running from steam, do you have a correct steam_appid.txt file?\n");
     }
@@ -36,6 +37,7 @@ EXTERN int luasteam_shutdown(lua_State *L) {
     luasteam::shutdown_user_stats(L);
     luasteam::shutdown_friends(L);
     luasteam::shutdown_common(L);
+    luasteam::shutdown_apps(L);
     return 0;
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,6 +5,7 @@
 #include "friends.hpp"
 #include "user.hpp"
 #include "user_stats.hpp"
+#include "apps.hpp"
 #include "utils.hpp"
 
 // Creates and returns a table with all functions
@@ -17,5 +18,6 @@ EXTERN int luaopen_luasteam(lua_State *L) {
     luasteam::add_utils(L);
     luasteam::add_UGC(L);
     luasteam::add_extra(L);
+    luasteam::add_apps(L);
     return 1;
 }


### PR DESCRIPTION
Adds the GetCurrentGameLanguage from the ISteamApps interface. This will
return a string of the users current language as per the steam docs.
Super useful for localisation purposes!

I have tested this locally on linux64 using the example code in the docs.