### PR TITLE
Add missing import to fix build

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -4,6 +4,7 @@
 #include "friends.hpp"
 #include "user_stats.hpp"
 #include "utils.hpp"
+#include "apps.hpp"
 
 // ========================
 // ======= SteamAPI =======


### PR DESCRIPTION
This import was missing when we added the ISteamApps implementation.
Adding it fixes the currently failing build.

I have tested this locally with linux64, but don't have the ability to test on
other OS'es.