### PR TITLE
provide more reasons why SteamAPI_Init might fail

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -28,7 +28,7 @@ EXTERN int luasteam_init(lua_State *L) {
         luasteam::init_networkingSockets(L);
         luasteam::init_networkingUtils(L);
     } else {
-        fprintf(stderr, "Couldn't connect to steam...\nDo you have Steam turned on?\nIf not running from steam, do you have a correct steam_appid.txt file?\n");
+        fprintf(stderr, "Couldn't connect to steam...\nPlease ensure that the following conditions are met:\n* Do you have Steam turned on?\n* If not running from steam, do you have a correct steam_appid.txt file?\n* Is the application running under the same user context as steam?\n* Is a license for the App ID present in your active steam account?\n* Is your App ID correctly set up, i.e. not in ``Release State: Unavailable`` and not missing default packages?\n");
     }
     lua_pushboolean(L, success);
     return 1;


### PR DESCRIPTION
I was helping my brother with his project, which uses luasteam, but couldn't get it to run initally. I would always receive the following error:

> [S_API] SteamAPI_Init(): Loaded '/home/nkt/.local/share/Steam/linux64/steamclient.so' OK.
> [S_API FAIL] SteamAPI_Init() failed; connect to global user failed.Couldn't connect to steam...
> Do you have Steam turned on?
> If not running from steam, do you have a correct steam_appid.txt file?

I had steam up and running and the `steam_appid.txt` had the correct app ID, so this wasn't it.
After digging through the documentation in `steam_api.rst`, I found several additional reasons, why this error could occur. It eventually turned out I was simply missing the product in my steam account, which was easy to remedy.

I suggest amending the existing error message with the additional information, which could help future users troubleshoot this problem more effectively 😊.