### PR TITLE
Add support for GetAuthTicketForWebApi

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -2,6 +2,7 @@
 #include "UGC.hpp"
 #include "extra.hpp"
 #include "friends.hpp"
+#include "user.hpp"
 #include "user_stats.hpp"
 #include "utils.hpp"
 #include "apps.hpp"
@@ -19,6 +20,7 @@ EXTERN int luasteam_init(lua_State *L) {
     if (success) {
         luasteam::init_common(L);
         luasteam::init_friends(L);
+        luasteam::init_user(L);
         luasteam::init_user_stats(L);
         luasteam::init_utils(L);
         luasteam::init_UGC(L);
@@ -45,6 +47,7 @@ EXTERN int luasteam_shutdown(lua_State *L) {
     luasteam::shutdown_extra(L);
     luasteam::shutdown_UGC(L);
     luasteam::shutdown_utils(L);
+    luasteam::shutdown_user(L);
     luasteam::shutdown_user_stats(L);
     luasteam::shutdown_friends(L);
     luasteam::shutdown_common(L);

--- a/src/user.cpp
+++ b/src/user.cpp
@@ -26,6 +26,7 @@ int user_ref = LUA_NOREF;
 class CallbackListener {
   private:
     STEAM_CALLBACK(CallbackListener, OnAuthSessionTicketResponse, GetAuthSessionTicketResponse_t);
+    STEAM_CALLBACK(CallbackListener, OnTicketForWebApiResponse, GetTicketForWebApiResponse_t);
 };
 
 void CallbackListener::OnAuthSessionTicketResponse(GetAuthSessionTicketResponse_t *data) {
@@ -45,6 +46,36 @@ void CallbackListener::OnAuthSessionTicketResponse(GetAuthSessionTicketResponse_
         lua_pushinteger(L, data->m_hAuthTicket);
         lua_setfield(L, -2, "handle");
         lua_pushstring(L, steam_result_code[data->m_eResult]);
+        lua_setfield(L, -2, "result");
+        lua_call(L, 1, 0);
+        lua_pop(L, 1);
+    }
+}
+
+void CallbackListener::OnTicketForWebApiResponse(GetTicketForWebApiResponse_t *data) {
+    if (data == nullptr) {
+        return;
+    }
+    lua_State* L = luasteam::global_lua_state;
+    if (!lua_checkstack(L, 4)) {
+        return;
+    }
+    lua_rawgeti(L, LUA_REGISTRYINDEX, user_ref);
+    lua_getfield(L, -1, "OnTicketForWebApiResponse");
+    if (lua_isnil(L, -1)) {
+        lua_pop(L, 2);
+    } else {
+        EResult result = data->m_eResult;
+        uint32 handle = data->m_hAuthTicket;
+        uint8 *authTicket = data->m_rgubTicket;
+        const char *hexTicket = bufferToHex(authTicket, 2560).c_str();
+
+        lua_createtable(L, 0, 1);
+        lua_pushinteger(L, handle);
+        lua_setfield(L, -2, "handle");
+        lua_pushstring(L, hexTicket);
+        lua_setfield(L, -2, "hexTicket");
+        lua_pushstring(L, steam_result_code[result]);
         lua_setfield(L, -2, "result");
         lua_call(L, 1, 0);
         lua_pop(L, 1);
@@ -88,6 +119,20 @@ EXTERN int luasteam_getAuthSessionTicket(lua_State *L) {
     return 1;
 }
 
+// HAuthTicket GetAuthTicketForWebApi( const char *pchIdentity );
+EXTERN int luasteam_getAuthTicketForWebApi(lua_State *L) {
+    const char *pchIdentity = luaL_checkstring(L, 1);
+    HAuthTicket ticket = SteamUser()->GetAuthTicketForWebApi(pchIdentity);
+    if (ticket != k_HAuthTicketInvalid) {
+        lua_newtable(L);
+        lua_pushinteger(L, ticket);
+        lua_setfield(L, -2, "handle");
+        return 1;
+    }
+    lua_pushnil(L);
+    return 1;
+}
+
 // void CancelAuthTicket( HAuthTicket hAuthTicket )
 EXTERN int luasteam_cancelAuthTicket(lua_State *L) {
     HAuthTicket ticket = luaL_checkinteger(L, 1);
@@ -102,6 +147,7 @@ void add_user(lua_State *L) {
     add_func(L, "getPlayerSteamLevel", luasteam_getPlayerSteamLevel);
     add_func(L, "getSteamID", luasteam_getSteamID);
     add_func(L, "getAuthSessionTicket", luasteam_getAuthSessionTicket);
+    add_func(L, "getAuthTicketForWebApi", luasteam_getAuthTicketForWebApi);
     add_func(L, "cancelAuthTicket", luasteam_cancelAuthTicket);
     lua_pushvalue(L, -1);
     user_ref = luaL_ref(L, LUA_REGISTRYINDEX);


### PR DESCRIPTION
## Motivation
Currently, it isn't possible to authenticate a steam user with a backend web server. Adding the function `GetAuthTicketForWebApi` and its associated callback handler `GetTicketForWebApiResponse_t` allows us to do so.

## Changes
- Added `init_user` and `shutdown_user` to `core.cpp`
  - Seems like these were omitted by mistake, preventing the `user.cpp` callback handlers from registering
- Added `user.getAuthTicketForWebApi` method and `OnTicketForWebApiResponse` callback handler
  -  [Steamworks docs](https://partner.steamgames.com/doc/api/ISteamUser#GetAuthTicketForWebApi) for `GetAuthTicketForWebApi`
  -  [Steamworks docs](https://partner.steamgames.com/doc/api/ISteamUser#GetTicketForWebApiResponse_t) for `GetTicketForWebApiResponse_t`

This is my first time writing C++, so please let me know if you have any suggestions for improving my code. Also let me know if there are any additional requirements for contribution I've missed.