### PR TITLE
Added -mmacosx-version-min=10.11 flag to osx compilation to increase backwards compatibility.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,11 @@ THIRD_PARTY=./third-party
 
 OSX_OUT=luasteam.so
 OSX_IPATHS=-I$(THIRD_PARTY)/include/
-OSX_FLAGS=$(OSX_IPATHS) $(STDLIB_VER)
+# Compile for 10.11 (El Capitan, 2015) and up. At the time of writing, 10.11 is the
+# minimum version libluajit-5.1.a is compiled for; targeting earlier versions will
+# raise compiler warnings.
+OSX_MIN_VERSION=-mmacosx-version-min=10.11
+OSX_FLAGS=$(OSX_IPATHS) $(STDLIB_VER) $(OSX_MIN_VERSION)
 
 GNU_OUT=luasteam.so
 # You might need to change this to luajit-2.1 depending on your install. Don't commit it.


### PR DESCRIPTION
I got a user report that achievements weren't unlocking on older versions of macOS, and it looks like luasteam (v3.2.1) wasn't being loaded since it was compiled for a more recent version.

```
Symbol not found: __ZNKSt3__115basic_stringbufIcNS_11char_traitsIcEENS_9allocatorIcEEE3strEv
  Referenced from: /Users/USER/Library/Application Support/BangAverageFootball/lib/osx_luasteam.so (which was built for Mac OS X 12.0)
  Expected in: /usr/lib/libc++.1.dylib
```

This PR adds the `-mmacosx-version-min=10.11` compiler flag to support macOS versions down to El Capitan (2015). 10.11 was chosen as this is the minimum macOS version that `libluajit-5.1.a` targets:

```
$ otool -l third-party/lib/libluajit-5.1.a | grep LC_VERSION_MIN_MACOSX -A 3
      cmd LC_VERSION_MIN_MACOSX
  cmdsize 16
  version 10.11
      sdk n/a
--
      cmd LC_VERSION_MIN_MACOSX
  cmdsize 16
  version 10.11
      sdk 14.5
--
etc.
```

Using an earlier version raises compiler warnings e.g.

```
ld: warning: object file (/Users/ruairi/dev/luasteam/third-party/lib/libluajit-5.1.a[x86_64][2](lj_vm.o)) was built for newer 'macOS' version (10.11) than being linked (10.10)
ld: warning: object file (/Users/ruairi/dev/luasteam/third-party/lib/libluajit-5.1.a[x86_64][4](lj_gc.o)) was built for newer 'macOS' version (10.11) than being linked (10.10)
ld: warning: object file (/Users/ruairi/dev/luasteam/third-party/lib/libluajit-5.1.a[x86_64][5](lj_err.o)) was built for newer 'macOS' version (10.11) than being linked (10.10)
ld: warning: object file (/Users/ruairi/dev/luasteam/third-party/lib/libluajit-5.1.a[x86_64][6](lj_char.o)) was built for newer 'macOS' version (10.11) than being linked (10.10)
ld: warning: object file (/Users/ruairi/dev/luasteam/third-party/lib/libluajit-5.1.a[x86_64][7](lj_bc.o)) was built for newer 'macOS' version (10.11) than being linked (10.10)
```

User has confirmed that achievements are now unlocking. I've also tested on x86_64 Ventura (13.X) and arm64 Sonoma (14.X) with Rosetta (although neither of these really test that the fix works for older versions, just that it still works for modern versions).

Happy to add some documentation in this PR explaining when we should bump this minimum version, although that should hopefully be obvious when the time comes (e.g. if libluajit is bumped and no longer supports 10.11, we should get compiler warnings similar to the ones above).