### PR TITLE
adding missing friends.getRichPresence() function.

### DIFF
--- a/docs/friends.rst
+++ b/docs/friends.rst
@@ -120,6 +120,8 @@ friends.getRichPresence(steamIDFriend, key)
     :SteamWorks: `GetRichPresence <https://partner.steamgames.com/doc/api/ISteamFriends#GetRichPresence>`_
 
 **Example**::
+    steam_id = getSteamIdSomehow()
+    print("Friend's text status is:", Steam.friends.getRichPresence(steam_id, "text"))
 
 .. function:: friends.inviteUserToGame(steamIDFriend, connect_string)
 

--- a/docs/friends.rst
+++ b/docs/friends.rst
@@ -9,6 +9,7 @@ List of Functions
 * :func:`friends.activateGameOverlayToWebPage`
 * :func:`friends.getFriendPersonaName`
 * :func:`friends.setRichPresence`
+* :func:`friends.getRichPresence`
 * :func:`friends.inviteUserToGame`
 * :func:`friends.getFriendCount`
 * :func:`friends.getFriendByIndex`
@@ -110,6 +111,15 @@ Function Reference
             }
         }
     }
+
+.. function::
+friends.getRichPresence(steamIDFriend, key)
+    :param uint64 steamIDFriend: The Steam ID of the friend to get rich presence of.
+    :param string key: The rich presence key to set. Maximum length is 64 characters.
+    :returns: (`string`) The value associated with the rich presence key. Maximum length is 256 characters. If this is ``''`` then the key has been removed or does not exists.
+    :SteamWorks: `GetRichPresence <https://partner.steamgames.com/doc/api/ISteamFriends#GetRichPresence>`_
+
+**Example**::
 
 .. function:: friends.inviteUserToGame(steamIDFriend, connect_string)
 

--- a/src/friends.cpp
+++ b/src/friends.cpp
@@ -96,6 +96,15 @@ EXTERN int luasteam_setRichPresence(lua_State *L) {
     return 1;
 }
 
+// const char * GetFriendRichPresence( CSteamID steamIDFriend, const char *pchKey );
+EXTERN int luasteam_getRichPresence(lua_State *L) {
+    CSteamID id(luasteam::checkuint64(L, 1));
+    const char *key = luaL_checkstring(L, 2);
+    const char *value = SteamFriends()->GetFriendRichPresence(id, key);
+    lua_pushstring(L, value);
+    return 1;
+}
+
 // bool InviteUserToGame( CSteamID steamIDFriend, const char *pchConnectString );
 EXTERN int luasteam_inviteUserToGame(lua_State *L) {
     CSteamID id(luasteam::checkuint64(L, 1));
@@ -133,6 +142,7 @@ void add_friends(lua_State *L) {
     add_func(L, "activateGameOverlayToWebPage", luasteam_activateGameOverlayToWebPage);
     add_func(L, "getFriendPersonaName", luasteam_getFriendPersonaName);
     add_func(L, "setRichPresence", luasteam_setRichPresence);
+    add_func(L, "getRichPresence", luasteam_getRichPresence);
     add_func(L, "inviteUserToGame", luasteam_inviteUserToGame);
     add_func(L, "getFriendCount", luasteam_getFriendCount);
     add_func(L, "getFriendByIndex", luasteam_getFriendByIndex);


### PR DESCRIPTION
I was reading the readthedocs documentation and found that the friends.getRichPresence(steamId, key) function was missing.

I have not tested this as I do not currently have access to a computer where I can put up the build environment required.
However this should work as this was rather easy to add.

(If there is a GitHub Actions build test runner then it should catch any errors.)