### PR TITLE
Makefile fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,13 +44,10 @@ WINDOWS_IPATHS=-I./cache/include
 WINDOWS_OPT=-LD -EHsc -Feluasteam
 VARSALL="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat"
 
-luajit.zip:
-	curl -sL -o luajit.zip http://luajit.org/download/LuaJIT-2.0.5.zip
-
-cache: luajit.zip
+cache:
 	@echo "Downloading LuaJIT source"
-	unzip -qo luajit.zip
 	mkdir cache\include
+	git clone --branch v2.0.5 https://github.com/LuaJIT/LuaJIT.git LuaJIT-2.0.5
 	cp LuaJIT-2.0.5/src/*.h cache/include
 
 cache/win32_lua51.lib:


### PR DESCRIPTION
Two main changes here:
1. The default installation directory of vcvarsall seems to have changed. Updated the path to reflect this.
2. Luajit no longer provides ZIP downloads, as [per the site](https://luajit.org/download.html) "Please do not use obsolete versions from older tarballs or zip files. Please remove any outdated links to these downloads — these links will cease to work soon". Attempting to download file returns an HTML file with the contents `<html><head><title>404 Not Found</title></head><body><h1>404 Not Found</h1></body></html>`.  I've updated the make file to clone the LuaJIT repo instead.
